### PR TITLE
feat: 현 위치 좌표를 도로명 주소로 변환, 키워드 장소 검색 

### DIFF
--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from 'react';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+interface Place {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
+const usePlaceSearch = (keyword: string): Place[] => {
+  const [places, setPlaces] = useState<Place[]>([]);
+
+  useEffect(() => {
+    const { kakao } = window;
+    if (!kakao || !keyword) {
+      setPlaces([]);
+      return;
+    }
+
+    const placesSearch = new kakao.maps.services.Places();
+
+    placesSearch.keywordSearch(keyword, (data: any, status: any) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const newPlaces = data.map((place: any) => ({
+          name: place.place_name,
+          address: place.address_name,
+          latitude: place.y,
+          longitude: place.x,
+        }));
+        setPlaces(newPlaces);
+      } else {
+        setPlaces([]);
+      }
+    });
+  }, [keyword]);
+
+  return places;
+};
+
+export default usePlaceSearch;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import safetCenter from '../assets/images/safetycenter.png';
 import fireStation from '../assets/images/firestation.png';
 import heatShelter from '../assets/images/heatshelter.png';
 import location from '../assets/images/location.png';
+import usePlaceSearch from '../hooks/usePlaceSearch';
 
 declare global {
   interface Window {
@@ -44,6 +45,11 @@ function Home() {
   const [currentPosition, setCurrentPosition] =
     useState<GeolocationPosition | null>(null);
   const [startAddress, setStartAddress] = useState<string>('');
+  const [endAddress, setEndAddress] = useState<string>('');
+  const startPlaces = usePlaceSearch(startAddress);
+  const endPlaces = usePlaceSearch(endAddress);
+  const [startIsSearching, setStartIsSearching] = useState<boolean>(false);
+  const [endIsSearching, setEndIsSearching] = useState<boolean>(false);
 
   useEffect(() => {
     // 위치 정보 요청
@@ -147,10 +153,58 @@ function Home() {
       <input
         type="text"
         value={startAddress}
-        onChange={(e) => setStartAddress(e.target.value)}
+        onChange={(e) => {
+          setStartIsSearching(true);
+          setStartAddress(e.target.value);
+        }}
         placeholder="출발지를 입력하세요"
       />
+      <input
+        type="text"
+        value={endAddress}
+        onChange={(e) => {
+          setEndIsSearching(true);
+          setEndAddress(e.target.value);
+        }}
+        placeholder="도착지를 입력하세요"
+      />
       <div id="map" style={{ width: '500px', height: '500px' }} />
+      <ul>
+        {startIsSearching &&
+          startPlaces.map((place, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={index}>
+              <button
+                type="button"
+                onClick={() => {
+                  setStartAddress(place.address);
+                  setStartIsSearching(false);
+                }}
+              >
+                <div>{place.name}</div>
+                <div>{place.address}</div>
+              </button>
+            </li>
+          ))}
+      </ul>
+      <ul>
+        {endIsSearching &&
+          endPlaces.map((place, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={index}>
+              <button
+                type="button"
+                onClick={() => {
+                  setEndAddress(place.address);
+                  setEndIsSearching(false);
+                }}
+              >
+                <div>{place.name}</div>
+                <div>{place.address}</div>
+              </button>
+            </li>
+          ))}
+      </ul>
     </>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import cctv from '../assets/images/cctv.png';
 import emergencyBell from '../assets/images/emergencybell.png';
 import safetFacility from '../assets/images/safetyfacility.png';
@@ -12,6 +12,11 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     kakao: any;
   }
+}
+
+interface AddressResult {
+  address: { address_name: string };
+  code: string;
 }
 
 const { kakao } = window;
@@ -36,42 +41,72 @@ const getImageSrc = (title: string) => {
 };
 
 function Home() {
-  const positions = [
-    {
-      title: 'cctv',
-      latlng: new kakao.maps.LatLng(33.450705, 126.570677),
-    },
-    {
-      title: 'safetyFacility',
-      latlng: new kakao.maps.LatLng(33.450936, 126.569477),
-    },
-    {
-      title: 'fireStation',
-      latlng: new kakao.maps.LatLng(33.450879, 126.56994),
-    },
-    {
-      title: 'heatShelter',
-      latlng: new kakao.maps.LatLng(33.450705, 126.572323),
-    },
-    {
-      title: 'saftyCenter',
-      latlng: new kakao.maps.LatLng(33.451502, 126.570766),
-    },
-    {
-      title: 'emergencyBell',
-      latlng: new kakao.maps.LatLng(33.449802, 126.570722),
-    },
-  ];
+  const [currentPosition, setCurrentPosition] =
+    useState<GeolocationPosition | null>(null);
 
   useEffect(() => {
+    // 위치 정보 요청
+    navigator.geolocation.getCurrentPosition(
+      (position: GeolocationPosition) => {
+        setCurrentPosition(position);
+      },
+      (error: GeolocationPositionError) => {
+        console.error('Error getting current position:', error);
+      },
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!currentPosition) return;
+
     const container = document.getElementById('map');
     const option = {
-      center: new kakao.maps.LatLng(33.450701, 126.570667),
+      center: new kakao.maps.LatLng(
+        currentPosition.coords.latitude,
+        currentPosition.coords.longitude,
+      ),
       level: 3,
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
     const map = new kakao.maps.Map(container, option);
+
+    const positions = [
+      {
+        title: 'cctv',
+        latlng: new kakao.maps.LatLng(37.486592, 126.9409552),
+      },
+      {
+        title: 'safetyFacility',
+        latlng: new kakao.maps.LatLng(37.486592, 126.938552),
+      },
+      {
+        title: 'fireStation',
+        latlng: new kakao.maps.LatLng(37.485592, 126.9409552),
+      },
+      {
+        title: 'heatShelter',
+        latlng: new kakao.maps.LatLng(37.487592, 126.9399552),
+      },
+      {
+        title: 'saftyCenter',
+        latlng: new kakao.maps.LatLng(37.486592, 126.9389552),
+      },
+      {
+        title: 'emergencyBell',
+        latlng: new kakao.maps.LatLng(37.486592, 126.9389552),
+      },
+    ];
+
+    // 현재 위치 마커 생성 및 추가
+    const currentPositionMarker = new kakao.maps.Marker({
+      position: new kakao.maps.LatLng(
+        currentPosition.coords.latitude,
+        currentPosition.coords.longitude,
+      ),
+      image: new kakao.maps.MarkerImage(location, new kakao.maps.Size(24, 32)),
+    });
+    currentPositionMarker.setMap(map);
 
     for (let i = 0; i < positions.length; i++) {
       const imageSrc = getImageSrc(positions[i].title);
@@ -79,15 +114,33 @@ function Home() {
 
       const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
 
-      // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
       const marker = new kakao.maps.Marker({
         map,
         position: positions[i].latlng,
         title: positions[i].title, // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됩니다
         image: markerImage,
       });
+      marker.setMap(map);
     }
-  }, []);
+  }, [currentPosition]);
+
+  useEffect(() => {
+    if (!currentPosition) return;
+
+    const geocoder = new kakao.maps.services.Geocoder();
+
+    const coord = new kakao.maps.LatLng(
+      currentPosition?.coords.latitude,
+      currentPosition?.coords.longitude,
+    );
+    const callback = (result: AddressResult[], status: string) => {
+      if (status === kakao.maps.services.Status.OK) {
+        console.log(result, result[0].address.address_name);
+      }
+    };
+
+    geocoder.coord2Address(coord.getLng(), coord.getLat(), callback);
+  }, [currentPosition]);
 
   return <div id="map" style={{ width: '500px', height: '500px' }} />;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -43,6 +43,7 @@ const getImageSrc = (title: string) => {
 function Home() {
   const [currentPosition, setCurrentPosition] =
     useState<GeolocationPosition | null>(null);
+  const [startAddress, setStartAddress] = useState<string>('');
 
   useEffect(() => {
     // 위치 정보 요청
@@ -104,13 +105,13 @@ function Home() {
         currentPosition.coords.latitude,
         currentPosition.coords.longitude,
       ),
-      image: new kakao.maps.MarkerImage(location, new kakao.maps.Size(24, 32)),
+      image: new kakao.maps.MarkerImage(location, new kakao.maps.Size(16, 22)),
     });
     currentPositionMarker.setMap(map);
 
     for (let i = 0; i < positions.length; i++) {
       const imageSrc = getImageSrc(positions[i].title);
-      const imageSize = new kakao.maps.Size(32, 32);
+      const imageSize = new kakao.maps.Size(16, 16);
 
       const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
 
@@ -128,21 +129,30 @@ function Home() {
     if (!currentPosition) return;
 
     const geocoder = new kakao.maps.services.Geocoder();
-
     const coord = new kakao.maps.LatLng(
       currentPosition?.coords.latitude,
       currentPosition?.coords.longitude,
     );
     const callback = (result: AddressResult[], status: string) => {
       if (status === kakao.maps.services.Status.OK) {
-        console.log(result, result[0].address.address_name);
+        setStartAddress(result[0].address.address_name);
       }
     };
 
     geocoder.coord2Address(coord.getLng(), coord.getLat(), callback);
   }, [currentPosition]);
 
-  return <div id="map" style={{ width: '500px', height: '500px' }} />;
+  return (
+    <>
+      <input
+        type="text"
+        value={startAddress}
+        onChange={(e) => setStartAddress(e.target.value)}
+        placeholder="출발지를 입력하세요"
+      />
+      <div id="map" style={{ width: '500px', height: '500px' }} />
+    </>
+  );
 }
 
 export default Home;


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
순찰 경로 알고리즘에 좌표가 아닌 도로명 주소가 들어가야 하므로 현 위치를 도로명 주소로 변환했습니다. 그리고 키워드로 장소를 검색하면 리스트 보여주고 선택할 수 있게 만들었습니다~ 

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->
- [x] 현 위치 좌표를 도로명 주소로 변환
- [x] 출발, 도착지 input 생성
- [x] 키워드로 장소 검색해서 리스트로 보여주기
- [x] 키워드 장소 검색 로직 훅으로 분리

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #9
Closes #16

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
지금은 현 위치를 컴포넌트가 처음 렌더링 될 때만 받아오는데요, 실시간으로 받아오려면 geolocation.watchPosition api를 사용하면 된다고 하네요. 실시간으로 안전시설도 받아오는 건 서버에 무리가 갈 것 같아서 어느 정도의 시간을 두고 받아와야 할지 고민해봐야 할 것 같아요!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
