### PR TITLE
feat: 티맵 api로 전환

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <script src="https://apis.openapi.sk.com/tmap/jsv2?version=1&appKey=REACT_APP_TMAP_API_KEY%"></script>
+    <script src="https://apis.openapi.sk.com/tmap/jsv2?version=1&appKey=%REACT_APP_TMAP_API_KEY%"></script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/public/index.html
+++ b/public/index.html
@@ -15,10 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%&libraries=services,drawing"
-    ></script>
+    <script src="https://apis.openapi.sk.com/tmap/jsv2?version=1&appKey=REACT_APP_TMAP_API_KEY%"></script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import usePlaceSearch from '../hooks/usePlaceSearch';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
+
 import { AddressInfo, SearchState } from '../types/mapTypes';
 
 interface Place {

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import usePlaceSearch from '../hooks/usePlaceSearch';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
+import { Coord, updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
 
-import { AddressInfo, SearchState } from '../types/mapTypes';
+import { SearchState } from '../types/mapTypes';
 
 interface Place {
   name: string;
@@ -17,12 +17,12 @@ interface SearchBoxProps {
   setSearchState: React.Dispatch<React.SetStateAction<SearchState>>;
   placeholder: string;
   places: Place[];
-  setAddressInfo: React.Dispatch<React.SetStateAction<AddressInfo>>;
+  setPosition: React.Dispatch<React.SetStateAction<Coord>>;
 }
 
 interface ContainerProps {
-  setStart: React.Dispatch<React.SetStateAction<AddressInfo>>;
-  setEnd: React.Dispatch<React.SetStateAction<AddressInfo>>;
+  setStartPosition: React.Dispatch<React.SetStateAction<Coord>>;
+  setEndPosition: React.Dispatch<React.SetStateAction<Coord>>;
 }
 
 function SearchBox({
@@ -30,7 +30,7 @@ function SearchBox({
   setSearchState,
   placeholder,
   places,
-  setAddressInfo,
+  setPosition,
 }: SearchBoxProps) {
   const { keyword, isSearching, selectedName } = searchState;
 
@@ -58,17 +58,15 @@ function SearchBox({
               <button
                 type="button"
                 onClick={() => {
+                  console.log(place);
                   setSearchState({
                     ...searchState,
                     isSearching: false,
                     selectedName: place.name,
                   });
-                  setAddressInfo({
-                    address: place.address,
-                    coord: {
-                      x: place.longitude,
-                      y: place.latitude,
-                    },
+                  setPosition({
+                    longitude: place.longitude,
+                    latitude: place.latitude,
                   });
                 }}
               >
@@ -82,7 +80,7 @@ function SearchBox({
   );
 }
 
-function SearchContainer({ setStart, setEnd }: ContainerProps) {
+function SearchContainer({ setStartPosition, setEndPosition }: ContainerProps) {
   const { currentPosition } = useCurrentPosition();
   const [startSearchState, setStartSearchState] = useState<SearchState>({
     keyword: '',
@@ -97,13 +95,14 @@ function SearchContainer({ setStart, setEnd }: ContainerProps) {
   });
   const endPlaces = usePlaceSearch(endSearchState.keyword);
 
+  console.log(startPlaces, endPlaces);
   // 혹시 나중에 출발지나 도착지를 현재 위치로 변경하는 기능을 추가할 때 유용할 것 같습니다.
   useEffect(() => {
     updateAddressFromCurrentCoordinates(
       currentPosition,
       setStartSearchState,
       startSearchState,
-      setStart,
+      setStartPosition,
     );
   }, [currentPosition]);
 
@@ -114,14 +113,14 @@ function SearchContainer({ setStart, setEnd }: ContainerProps) {
         setSearchState={setStartSearchState}
         placeholder="출발지를 입력하세요"
         places={startPlaces}
-        setAddressInfo={setStart}
+        setPosition={setStartPosition}
       />
       <SearchBox
         searchState={endSearchState}
         setSearchState={setEndSearchState}
         placeholder="도착지를 입력하세요"
         places={endPlaces}
-        setAddressInfo={setEnd}
+        setPosition={setEndPosition}
       />
     </>
   );

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,16 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import usePlaceSearch from '../hooks/usePlaceSearch';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { Coord, updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
-
-import { SearchState } from '../types/mapTypes';
-
-interface Place {
-  name: string;
-  address: string;
-  latitude: number;
-  longitude: number;
-}
+import { updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
+import { Coord, SearchState, Place } from '../types/mapTypes';
 
 interface SearchBoxProps {
   searchState: SearchState;
@@ -58,7 +50,6 @@ function SearchBox({
               <button
                 type="button"
                 onClick={() => {
-                  console.log(place);
                   setSearchState({
                     ...searchState,
                     isSearching: false,
@@ -95,7 +86,6 @@ function SearchContainer({ setStartPosition, setEndPosition }: ContainerProps) {
   });
   const endPlaces = usePlaceSearch(endSearchState.keyword);
 
-  console.log(startPlaces, endPlaces);
   // 혹시 나중에 출발지나 도착지를 현재 위치로 변경하는 기능을 추가할 때 유용할 것 같습니다.
   useEffect(() => {
     updateAddressFromCurrentCoordinates(

--- a/src/constant/mockingPositions.ts
+++ b/src/constant/mockingPositions.ts
@@ -1,6 +1,5 @@
-import { FacilitiesType } from '../types/mapTypes';
+import { Tmapv2, FacilitiesType } from '../types/mapTypes';
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Tmapv2 } from '../hooks/useMap';
 
 interface MockedPositionType {
   title: FacilitiesType;

--- a/src/constant/mockingPositions.ts
+++ b/src/constant/mockingPositions.ts
@@ -1,9 +1,9 @@
 import { FacilitiesType } from '../types/mapTypes';
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Tmapv2 } from '../hooks/useMap';
 
 interface MockedPositionType {
-  title: FacilitiesType
-  // latlng: kakao.maps.LatLng;
+  title: FacilitiesType;
   latlng: any;
   lat: number;
   lng: number;
@@ -12,39 +12,39 @@ interface MockedPositionType {
 const POSITIONS: MockedPositionType[] = [
   {
     title: 'cctv',
-    latlng: new window.kakao.maps.LatLng(37.486592, 126.9409552),
+    latlng: new Tmapv2.LatLng(37.486592, 126.9409552),
     lat: 37.486592,
-    lng: 126.9409552
+    lng: 126.9409552,
   },
   {
     title: 'safetyFacility',
-    latlng: new window.kakao.maps.LatLng(37.486592, 126.938552),
+    latlng: new Tmapv2.LatLng(37.486592, 126.938552),
     lat: 37.486592,
-    lng: 126.938552
+    lng: 126.938552,
   },
   {
     title: 'fireStation',
-    latlng: new window.kakao.maps.LatLng(37.485592, 126.9409552),
+    latlng: new Tmapv2.LatLng(37.485592, 126.9409552),
     lat: 37.485592,
-    lng: 126.9409552
+    lng: 126.9409552,
   },
   {
     title: 'heatShelter',
-    latlng: new window.kakao.maps.LatLng(37.487592, 126.9399552),
+    latlng: new Tmapv2.LatLng(37.487592, 126.9399552),
     lat: 37.487592,
-    lng: 126.9399552
+    lng: 126.9399552,
   },
   {
     title: 'saftyCenter',
-    latlng: new window.kakao.maps.LatLng(37.486592, 126.9389552),
+    latlng: new Tmapv2.LatLng(37.486592, 126.9389552),
     lat: 37.486592,
-    lng: 126.9389552
+    lng: 126.9389552,
   },
   {
     title: 'emergencyBell',
-    latlng: new window.kakao.maps.LatLng(37.486592, 126.9389552),
+    latlng: new Tmapv2.LatLng(37.486592, 126.9389552),
     lat: 37.486592,
-    lng: 126.9389552
+    lng: 126.9389552,
   },
 ];
 

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -6,10 +6,11 @@ function useMap(
   lat: number | undefined,
   lng: number | undefined,
 ) {
-  const [map, setMap] = useState(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [map, setMap] = useState<any>(null);
 
   useEffect(() => {
-    if (!lat || !lng) return;
+    if (!lat || !lng || !containerRef.current) return;
     if (containerRef.current) {
       const options = {
         center: new Tmapv2.LatLng(lat, lng),
@@ -18,7 +19,14 @@ function useMap(
       const newMap = new Tmapv2.Map(containerRef.current, options);
       setMap(newMap);
     }
-  }, [lat, lng]);
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      if (map) {
+        map.remove();
+      }
+    };
+  }, [lat, lng, containerRef]);
   return { map };
 }
 

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,26 +1,30 @@
 import React, { useEffect, useState } from 'react';
 
 declare global {
-    interface Window {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      kakao: any;
-    }
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Tmapv2: any;
   }
+}
 
-const { kakao } = window;
+export const { Tmapv2 } = window;
 
-function useMap(containerRef: React.RefObject<HTMLDivElement>, lat: number | undefined, lng: number | undefined) {
+function useMap(
+  containerRef: React.RefObject<HTMLDivElement>,
+  lat: number | undefined,
+  lng: number | undefined,
+) {
   const [map, setMap] = useState(null);
 
   useEffect(() => {
     if (!lat || !lng) return;
     if (containerRef.current) {
       const options = {
-        center: new kakao.maps.LatLng(lat, lng),
-        level: 3,
+        center: new Tmapv2.LatLng(lat, lng),
+        zoom: 15,
       };
-      const Map = new kakao.maps.Map(containerRef.current, options);
-      setMap(Map);
+      const newMap = new Tmapv2.Map(containerRef.current, options);
+      setMap(newMap);
     }
   }, [lat, lng]);
   return { map };

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,13 +1,5 @@
 import React, { useEffect, useState } from 'react';
-
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Tmapv2: any;
-  }
-}
-
-export const { Tmapv2 } = window;
+import { Tmapv2 } from '../types/mapTypes';
 
 function useMap(
   containerRef: React.RefObject<HTMLDivElement>,

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
+import { searchPOI } from '../utils/mapUtils';
 
 declare global {
   interface Window {
@@ -18,27 +19,11 @@ const usePlaceSearch = (keyword: string): Place[] => {
   const [places, setPlaces] = useState<Place[]>([]);
 
   useEffect(() => {
-    const { kakao } = window;
-    if (!kakao || !keyword) {
-      setPlaces([]);
-      return;
+    if (keyword) {
+      searchPOI(keyword, setPlaces);
     }
 
-    const placesSearch = new kakao.maps.services.Places();
-
-    placesSearch.keywordSearch(keyword, (data: any, status: any) => {
-      if (status === kakao.maps.services.Status.OK) {
-        const newPlaces = data.map((place: any) => ({
-          name: place.place_name,
-          address: place.address_name,
-          latitude: place.y,
-          longitude: place.x,
-        }));
-        setPlaces(newPlaces);
-      } else {
-        setPlaces([]);
-      }
-    });
+    return () => {};
   }, [keyword]);
 
   return places;

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,19 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 import { searchPOI } from '../utils/mapUtils';
-
-declare global {
-  interface Window {
-    kakao: any;
-  }
-}
-
-interface Place {
-  name: string;
-  address: string;
-  latitude: number;
-  longitude: number;
-}
+import { Place } from '../types/mapTypes';
 
 const usePlaceSearch = (keyword: string): Place[] => {
   const [places, setPlaces] = useState<Place[]>([]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,9 @@ const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <App />,
+  // </React.StrictMode>,
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -23,7 +23,7 @@ function EmergencyPage() {
     const lat = currentPosition.coords.latitude;
     const lng = currentPosition.coords.longitude;
 
-    const marker = generateMarker(lat, lng);
+    const marker = generateMarker(map, lat, lng);
     marker.setMap(map);
 
     const infoWindow = generateInfoWindow(lat, lng);

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import useMap from '../hooks/useMap';
 import {
   generateMarker,
-  generateCircle,
+  drawCircle,
   generateInfoWindow,
 } from '../utils/mapUtils';
 
@@ -26,11 +26,9 @@ function EmergencyPage() {
     const marker = generateMarker(map, lat, lng);
     marker.setMap(map);
 
-    const infoWindow = generateInfoWindow(lat, lng);
-    infoWindow.open(map, marker);
+    generateInfoWindow(marker);
 
-    const circle = generateCircle(lat, lng);
-    circle.setMap(map);
+    drawCircle(map, lat, lng);
   }, [map, currentPosition]);
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,14 +3,13 @@ import React, { useState, useEffect, useRef } from 'react';
 import useMap from '../hooks/useMap';
 import POSITIONS from '../constant/mockingPositions';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { generateMarker, findway, kakao, reverseGeo } from '../utils/mapUtils';
+import { generateMarker, findway, kakao } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
 import { AddressInfo } from '../types/mapTypes';
 import BottomSheet from '../components/BottomSheet';
 
 function Home() {
   const { currentPosition } = useCurrentPosition();
-  console.log(currentPosition);
   const mapRef = useRef(null);
   const { map } = useMap(
     mapRef,
@@ -18,7 +17,6 @@ function Home() {
     currentPosition?.coords.longitude,
   );
 
-  reverseGeo(126.98702028, 37.5652045);
   const [start, setStart] = useState<AddressInfo>({
     address: '',
     coord: { x: undefined, y: undefined },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,19 +3,22 @@ import React, { useState, useEffect, useRef } from 'react';
 import useMap from '../hooks/useMap';
 import POSITIONS from '../constant/mockingPositions';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { generateMarker, findway, kakao } from '../utils/mapUtils';
+import { generateMarker, findway, kakao, reverseGeo } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
 import { AddressInfo } from '../types/mapTypes';
 import BottomSheet from '../components/BottomSheet';
 
 function Home() {
   const { currentPosition } = useCurrentPosition();
+  console.log(currentPosition);
   const mapRef = useRef(null);
   const { map } = useMap(
     mapRef,
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
+
+  reverseGeo(126.98702028, 37.5652045);
   const [start, setStart] = useState<AddressInfo>({
     address: '',
     coord: { x: undefined, y: undefined },
@@ -50,6 +53,7 @@ function Home() {
 
     // 현재 위치 마커 생성 및 추가
     const currentPositionMarker = generateMarker(
+      map,
       currentPosition.coords.latitude,
       currentPosition.coords.longitude,
     );
@@ -58,6 +62,7 @@ function Home() {
     // 위험 시설 마커 생성 및 추가
     for (let i = 0; i < POSITIONS.length; i++) {
       const marker = generateMarker(
+        map,
         POSITIONS[i].lat,
         POSITIONS[i].lng,
         POSITIONS[i].title,
@@ -76,6 +81,7 @@ function Home() {
         polyline.setMap(null);
       }
       const newStartMarker = generateMarker(
+        map,
         start.coord.y,
         start.coord.x,
         'way',
@@ -91,7 +97,7 @@ function Home() {
       if (polyline) {
         polyline.setMap(null);
       }
-      const newEndMarker = generateMarker(end.coord.y, end.coord.x, 'way');
+      const newEndMarker = generateMarker(map, end.coord.y, end.coord.x, 'way');
       newEndMarker.setMap(map);
       setEndMarker(newEndMarker);
     }
@@ -103,7 +109,11 @@ function Home() {
       <button type="button" onClick={findAndDrawPath}>
         길찾기
       </button>
-      <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
+      <div
+        id="map_div"
+        style={{ width: '500px', height: '500px' }}
+        ref={mapRef}
+      />
       <BottomSheet />
     </>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,9 +3,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import useMap from '../hooks/useMap';
 import POSITIONS from '../constant/mockingPositions';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { generateMarker, Coord, drawRoute } from '../utils/mapUtils';
+import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
 import BottomSheet from '../components/BottomSheet';
+import { Coord } from '../types/mapTypes';
 
 function Home() {
   const { currentPosition } = useCurrentPosition();
@@ -30,7 +31,7 @@ function Home() {
     { latitude: 37.397153, longitude: 127.113403 },
   ]);
 
-  console.log(startPosition, endPosition);
+  // console.log(startPosition, endPosition);
 
   useEffect(() => {
     if (!currentPosition) return;

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -1,3 +1,12 @@
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Tmapv2: any;
+  }
+}
+
+export const { Tmapv2 } = window;
+
 export type FacilitiesType =
   | 'cctv'
   | 'fireStation'
@@ -13,8 +22,14 @@ export interface SearchState {
   selectedName: string;
 }
 
-export interface AddressInfo {
+export interface Coord {
+  longitude: number | undefined;
+  latitude: number | undefined;
+}
+
+export interface Place {
+  name: string;
   address: string;
-  // x: 경도 y: 위도
-  coord: { x: number | undefined; y: number | undefined };
+  latitude: number;
+  longitude: number;
 }

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -17,15 +17,6 @@ import {
   Place,
 } from '../types/mapTypes';
 
-declare global {
-  interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    kakao: any;
-  }
-}
-
-export const { kakao } = window;
-
 const getImageSrc = (facilities?: FacilitiesType) => {
   switch (facilities) {
     case 'cctv':
@@ -68,28 +59,29 @@ export function generateMarker(
   return marker;
 }
 
-export function generateInfoWindow(lat: number, lng: number) {
-  const iwContent = '<div style="padding:5px;">Hello World!</div>';
-  const iwPosition = new kakao.maps.LatLng(lat, lng);
-  const infoWindow = new kakao.maps.InfoWindow({
-    position: iwPosition,
-    content: iwContent,
+export function generateInfoWindow(marker: any) {
+  const infoWindow = new Tmapv2.InfoWindow({
+    content: '신고 위치',
+    position: marker.getPosition(),
   });
   return infoWindow;
 }
 
-export function generateCircle(lat: number, lng: number) {
-  const circle = new kakao.maps.Circle({
-    center: new kakao.maps.LatLng(lat, lng),
-    radius: 250,
+export const drawCircle = (map: any, lat: number, lng: number) => {
+  const drawingObject = new Tmapv2.extension.Drawing({
+    map,
+    center: new Tmapv2.LatLng(lat, lng),
     strokeWeight: 1,
     strokeColor: '#007470',
-    strokeStyle: 'solid',
+    strokeOpacity: 1,
     fillColor: '#007470',
     fillOpacity: 0.15,
   });
-  return circle;
-}
+  // 도형 객체의 원을 그리는 함수
+  if (drawingObject) {
+    drawingObject.drawCircle();
+  }
+};
 
 export async function reverseGeo(lon: number, lat: number) {
   try {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -12,10 +12,12 @@ import way from '../assets/images/way.png';
 import { FacilitiesType, SearchState, AddressInfo } from '../types/mapTypes';
 import { Tmapv2 } from '../hooks/useMap';
 
-// interface AddressResult {
-//   address: { address_name: string };
-//   code: string;
-// }
+export interface Place {
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+}
 
 declare global {
   interface Window {
@@ -172,7 +174,7 @@ export async function updateAddressFromCurrentCoordinates(
     currentPosition?.coords.latitude,
   );
 
-  console.log(response);
+  // console.log(response);
   // TODO: response가 null이 되지 않게
   setStartSearchState({
     ...startSearchState,
@@ -239,3 +241,37 @@ export async function findway(start: AddressInfo, end: AddressInfo) {
 
   return linePath;
 }
+
+export const searchPOI = async (
+  keyword: string,
+  setPlaces: React.Dispatch<React.SetStateAction<Place[]>>,
+) => {
+  try {
+    const headers = {
+      appKey: process.env.REACT_APP_TMAP_API_KEY,
+    };
+
+    const response = await axios.get('https://apis.openapi.sk.com/tmap/pois', {
+      params: {
+        version: 1,
+        format: 'json',
+        searchKeyword: keyword,
+        resCoordType: 'EPSG3857',
+        reqCoordType: 'WGS84GEO',
+        count: 10,
+      },
+      headers,
+    });
+
+    const resultpoisData = response.data.searchPoiInfo?.pois?.poi;
+    if (!resultpoisData) {
+      console.error('No POIs');
+      return;
+    }
+    // console.log(resultpoisData);
+
+    setPlaces(resultpoisData);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+};


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
카카오맵 api에는 도보 경로 찾기가 없어서 도보 경로 찾기를 지원하는 티맵 api로 전환했습니다.

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 카카오맵으로 구현했던 지도, 마커, 장소 검색, 경로 탐색 및 시각화 기능을 티맵으로 전환했어요.
- [x] useMap 훅에서 컴포넌트가 마운트될 때마다 맵을 생성하지만 언마운트될 때 제거하지 않아 새로운 맵이 추가되는 버그를 해결했어요. 언마운트될 때 맵을 제거하는 로직을 추가했어요.

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->
Closes #29 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- .env에 REACT_APP_TMAP_API_KEY를 추가해주세요
- 제가 오늘 개발하면서 하루 할당량의 80% 이상을 사용했어요. 민수님이 앱을 생성해 다른 키를 사용해야 할 수도 있을 것 같아요! 그리고 팀원 초대 수락해주세요~
- 카카오맵과 달리 인포 윈도우가 따로 있지 않고 돔을 조작해야 하는 것 같아요. 그리고 원 그리는 부분도 제대로 구현해 놓지 못했어요. 사실 집중력을 잃었어요ㅠㅠ 민수님이 좀 더 손봐주시면 감사하겠습니다!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
