### PR TITLE
fix: 새로운 경로 탐색시 이전 경로, 마커 지우도록 수정

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,7 +24,8 @@ function Home() {
     latitude: undefined,
     longitude: undefined,
   });
-  const [, setPolylines] = useState<any[]>([]);
+  const [polylines, setPolylines] = useState<any[]>([]);
+  const [markers, setMarkers] = useState<any[]>([]);
   const [waypoints] = useState([
     { latitude: 37.48213002, longitude: 126.94363778 },
     { latitude: 37.48223002, longitude: 126.94353778 },
@@ -32,7 +33,7 @@ function Home() {
   ]);
 
   console.log(startPosition, endPosition);
-
+  console.log(polylines);
   useEffect(() => {
     if (!currentPosition) return;
 
@@ -55,12 +56,23 @@ function Home() {
   }, [map]);
 
   useEffect(() => {
-    if (map) {
-      drawRoute(map, startPosition, endPosition, waypoints)
-        .then((newPolylines) => setPolylines(newPolylines))
-        .catch((error) => console.error('Error drawing route:', error));
-    }
-  }, [startPosition, endPosition, waypoints]);
+    if (!map) return;
+
+    drawRoute(map, startPosition, endPosition, waypoints, polylines, markers)
+      .then(
+        ({
+          newPolylines,
+          newMarkers,
+        }: {
+          newPolylines: any[];
+          newMarkers: any[];
+        }) => {
+          setPolylines(newPolylines);
+          setMarkers(newMarkers);
+        },
+      )
+      .catch((error) => console.error('Error drawing route:', error));
+  }, [map, startPosition, endPosition, waypoints]);
 
   return (
     <>
@@ -68,12 +80,12 @@ function Home() {
         setStartPosition={setStartPosition}
         setEndPosition={setEndPosition}
       />
-      <button
+      {/* <button
         type="button"
         onClick={() => drawRoute(map, startPosition, endPosition, waypoints)}
       >
         길찾기
-      </button>
+      </button> */}
       <div
         id="map_div"
         style={{ width: '500px', height: '500px' }}


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
새로운 경로를 탐색하는데 이전 경로와 마커가 사라지지 않고 덧그려지는 문제가 있어서 해결했습니다.

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 티맵에 경로 안내 요청 보내기 전에 기존 폴리라인과, 마커를 제거하는 로직을 추가했어요!
- [x] drawRoute 함수에서 features를 순회하면서 매번 경유지 마커를 생성하고 있던 문제를 발견해서 한번만 생성하도록 수정했어요.

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #40 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
