### PR TITLE
feat : BottomSheet 필터링 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import {
   createBrowserRouter,
   RouterProvider,
 } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import Home from './pages/Home';
 import EmergencyPage from './pages/EmergencyPage';
 
@@ -13,7 +14,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/emergency',
-    element: <EmergencyPage />,
+    element: null,
     children: [
       {
         path: ':emergencyId',
@@ -25,7 +26,9 @@ const router = createBrowserRouter([
 
 function App() {
   return (
-    <RouterProvider router={router} />
+    <RecoilRoot>
+      <RouterProvider router={router} />
+    </RecoilRoot>
   );
 }
 

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -3,9 +3,13 @@ import { BottomSheetContent, Wrapper } from './style';
 import BottomSheetHeader from '../BottomSheetHeader';
 import Content from '../BottomSheetContents';
 import useBottomSheet from '../../hooks/useBottomSheet';
+import { EXTRAPOSITIONS } from '../../constant/mockingPositions';
+import useFilteringMarker from '../../hooks/useFilteringMarker';
 
-function BottomSheet() {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function BottomSheet({map}:any) {
   const { sheet, content } = useBottomSheet();
+  useFilteringMarker(map, EXTRAPOSITIONS);
 
   return (
     <Wrapper ref={sheet}>

--- a/src/components/BottomSheetContents/index.tsx
+++ b/src/components/BottomSheetContents/index.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import POSITIONS from '../../constant/mockingPositions';
+import { useRecoilState } from 'recoil';
+import { POSITIONTITLE } from '../../constant/mockingPositions';
 import { FacilityButton, ButtonWrapper, Wrapper, ReportBtn, Label, ReportListWrapper} from './style';
 import ReportList from '../ReportList';
+import filterState from '../../recoil/atoms';
 
 function Content(){
   const [isChecked, setIsChecked] = useState(false);
-  const [isClicked, setIsClicked] = useState(new Array(POSITIONS.length).fill(false));
+  const [currentFilters, setCurrentFilters] = useRecoilState(filterState);
 
-  const handleButtonClick = (index: number) => {
-    const newIsClicked = [...isClicked];
-    newIsClicked[index] = !newIsClicked[index];
-    setIsClicked(newIsClicked);
+  const handleButtonClick = (title:string) => {
+    setCurrentFilters({
+      ...currentFilters,
+      [title]: !currentFilters[title],
+    });
   };
 
   const handleChange = () => {
@@ -18,11 +21,10 @@ function Content(){
   };
 
   useEffect(() => {
-    setIsClicked(new Array(POSITIONS.length).fill(isChecked));
+    setCurrentFilters(Object.fromEntries(Object.entries(currentFilters).map(([key]) => [key, isChecked])));
   }, [isChecked]);
 
   function traslateToKorean(input: string): string {
-
     switch(input) {
       case 'cctv':
         return 'CCTV';
@@ -54,14 +56,14 @@ function Content(){
           안전시설 모두보기
         </Label>
         <ButtonWrapper>
-          {POSITIONS.map((position, index) => (
+          {POSITIONTITLE.map((position) => (
             <FacilityButton
-              key={`facilityBtn_${position.title}`}
-              $isClicked={isClicked[index]}
-              onMouseDown={() => handleButtonClick(index)}
+              key={`facilityBtn_${position}`}
+              $isClicked={currentFilters[position]}
+              onMouseDown={() => handleButtonClick(position)}
               type='button'
             >
-              {(traslateToKorean(position.title))}
+              {(traslateToKorean(position))}
             </FacilityButton>
           ))}
         </ButtonWrapper>

--- a/src/constant/mockingPositions.ts
+++ b/src/constant/mockingPositions.ts
@@ -1,50 +1,163 @@
 import { Tmapv2, FacilitiesType } from '../types/mapTypes';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-interface MockedPositionType {
+export interface MockedPositionType {
   title: FacilitiesType;
   latlng: any;
   lat: number;
   lng: number;
 }
 
-const POSITIONS: MockedPositionType[] = [
-  {
-    title: 'cctv',
-    latlng: new Tmapv2.LatLng(37.486592, 126.9409552),
-    lat: 37.486592,
-    lng: 126.9409552,
-  },
-  {
-    title: 'safetyFacility',
-    latlng: new Tmapv2.LatLng(37.486592, 126.938552),
-    lat: 37.486592,
-    lng: 126.938552,
-  },
-  {
-    title: 'fireStation',
-    latlng: new Tmapv2.LatLng(37.485592, 126.9409552),
-    lat: 37.485592,
-    lng: 126.9409552,
-  },
-  {
-    title: 'heatShelter',
-    latlng: new Tmapv2.LatLng(37.487592, 126.9399552),
-    lat: 37.487592,
-    lng: 126.9399552,
-  },
-  {
-    title: 'saftyCenter',
-    latlng: new Tmapv2.LatLng(37.486592, 126.9389552),
-    lat: 37.486592,
-    lng: 126.9389552,
-  },
-  {
-    title: 'emergencyBell',
-    latlng: new Tmapv2.LatLng(37.486592, 126.9389552),
-    lat: 37.486592,
-    lng: 126.9389552,
-  },
-];
+export const EXTRAPOSITIONS: MockedPositionType[] = [{
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.64962573412779, 127.11504591714298),
+  'lat': 37.64962573412779,
+  'lng': 127.11504591714298
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.68072864628185, 126.90181668699964),
+  'lat': 37.68072864628185,
+  'lng': 126.90181668699964
+}, {
+  'title': 'cctv',
+  'latlng': new Tmapv2.LatLng(37.55450254974857, 127.01393249069437),
+  'lat': 37.55450254974857,
+  'lng': 127.01393249069437
+}, {
+  'title': 'heatShelter',
+  'latlng': new Tmapv2.LatLng(37.44109400943535, 126.93263715735526),
+  'lat': 37.44109400943535,
+  'lng': 126.93263715735526
+}, {
+  'title': 'safetyFacility',
+  'latlng': new Tmapv2.LatLng(37.66259829457774, 126.8083975475223),
+  'lat': 37.66259829457774,
+  'lng': 126.8083975475223
+}, {
+  'title': 'safetyFacility',
+  'latlng': new Tmapv2.LatLng(37.60695791324267, 126.79316209701774),
+  'lat': 37.60695791324267,
+  'lng': 126.79316209701774
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.65305891174702, 126.76806290751455),
+  'lat': 37.65305891174702,
+  'lng': 126.76806290751455
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.573619452071085, 127.01597452833518),
+  'lat': 37.573619452071085,
+  'lng': 127.01597452833518
+}, {
+  'title': 'cctv',
+  'latlng': new Tmapv2.LatLng(37.59913063423765, 127.10149578560635),
+  'lat': 37.59913063423765,
+  'lng': 127.10149578560635
+}, {
+  'title': 'safetyFacility',
+  'latlng': new Tmapv2.LatLng(37.679084014027424, 127.15896446310936),
+  'lat': 37.679084014027424,
+  'lng': 127.15896446310936
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.49845463160961, 126.94007376296142),
+  'lat': 37.49845463160961,
+  'lng': 126.94007376296142
+}, {
+  'title': 'cctv',
+  'latlng': new Tmapv2.LatLng(37.59897664847852, 127.16406222426656),
+  'lat': 37.59897664847852,
+  'lng': 127.16406222426656
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.505337052136255, 127.10747391682135),
+  'lat': 37.505337052136255,
+  'lng': 127.10747391682135
+}, {
+  'title': 'heatShelter',
+  'latlng': new Tmapv2.LatLng(37.428676694040455, 126.97636994666635),
+  'lat': 37.428676694040455,
+  'lng': 126.97636994666635
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.68567659030394, 127.08057259433093),
+  'lat': 37.68567659030394,
+  'lng': 127.08057259433093
+}, {
+  'title': 'safetyFacility',
+  'latlng': new Tmapv2.LatLng(37.67916484813188, 126.87580869551581),
+  'lat': 37.67916484813188,
+  'lng': 126.87580869551581
+}, {
+  'title': 'heatShelter',
+  'latlng': new Tmapv2.LatLng(37.44126035414257, 127.0422893958011),
+  'lat': 37.44126035414257,
+  'lng': 127.0422893958011
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.56636858041499, 127.07219489981215),
+  'lat': 37.56636858041499,
+  'lng': 127.07219489981215
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.63885286489996, 127.07580704421247),
+  'lat': 37.63885286489996,
+  'lng': 127.07580704421247
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.54914572187157, 126.94933302584089),
+  'lat': 37.54914572187157,
+  'lng': 126.94933302584089
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.64269276933789, 127.09306797623269),
+  'lat': 37.64269276933789,
+  'lng': 127.09306797623269
+}, {
+  'title': 'saftyCenter',
+  'latlng': new Tmapv2.LatLng(37.58359991403163, 126.93638213559551),
+  'lat': 37.58359991403163,
+  'lng': 126.93638213559551
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.520572834739966, 127.02923327689213),
+  'lat': 37.520572834739966,
+  'lng': 127.02923327689213
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.56462824570889, 126.91616304904088),
+  'lat': 37.56462824570889,
+  'lng': 126.91616304904088
+}, {
+  'title': 'emergencyBell',
+  'latlng': new Tmapv2.LatLng(37.53668800482912, 127.02166820551248),
+  'lat': 37.53668800482912,
+  'lng': 127.02166820551248
+}, {
+  'title': 'saftyCenter',
+  'latlng': new Tmapv2.LatLng(37.447135955201055, 127.08560447109214),
+  'lat': 37.447135955201055,
+  'lng': 127.08560447109214
+}, {
+  'title': 'safetyFacility',
+  'latlng': new Tmapv2.LatLng(37.56582802537122, 127.07335943054802),
+  'lat': 37.56582802537122,
+  'lng': 127.07335943054802
+}, {
+  'title': 'fireStation',
+  'latlng': new Tmapv2.LatLng(37.539428938972264, 127.00580491374272),
+  'lat': 37.539428938972264,
+  'lng': 127.00580491374272
+}, {
+  'title': 'cctv',
+  'latlng': new Tmapv2.LatLng(37.68041918035814, 127.07243097763381),
+  'lat': 37.68041918035814,
+  'lng': 127.07243097763381
+}, {
+  'title': 'cctv',
+  'latlng': new Tmapv2.LatLng(37.54791630169807, 126.79833336814202),
+  'lat': 37.54791630169807,
+  'lng': 126.79833336814202
+}];
 
-export default POSITIONS;
+export const POSITIONTITLE = [ 'cctv', 'fireStation', 'safetyFacility', 'saftyCenter', 'emergencyBell', 'heatShelter'];

--- a/src/hooks/useFilteringMarker.ts
+++ b/src/hooks/useFilteringMarker.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { MockedPositionType } from '../constant/mockingPositions';
+import { generateMarker } from '../utils/mapUtils';
+import filterState from '../recoil/atoms';
+
+interface FacilityMarkerType {
+    title: string;
+    visible: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    marker: any;
+  }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function useFilteringMarker(map:any, facilityData: MockedPositionType[]) {
+  const [facilityMarker, setFacilityMarker] = useState<FacilityMarkerType[]>([]);
+  const filterValue = useRecoilValue(filterState);
+
+  useEffect(() => {
+    const filteredMarkerData = facilityData.map(position => {
+      const marker = generateMarker(map, position.lat, position.lng, position.title);
+      return {
+        title: position.title,
+        visible: false,
+        marker,
+      };
+    });
+    setFacilityMarker(filteredMarkerData);
+  }, [map, facilityData]);
+
+  // 필터링값을 확인하고, facilityMarker 데이터를 업데이트함
+  useEffect(() => {
+    const newFacilityMarker = facilityMarker.map(marker => {
+      return {
+        ...marker,
+        visible: filterValue[marker.title]
+      };
+    });
+    setFacilityMarker(newFacilityMarker);
+  }, [filterValue]);
+
+  useEffect(() => {
+    facilityMarker.forEach(marker => {
+      if (marker.visible) marker.marker.setMap(map);
+      else marker.marker.setMap(null);
+    });
+  }, [facilityMarker]);
+
+}
+
+export default useFilteringMarker;
+

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -15,11 +15,12 @@ import { convertDateFormat } from '../components/ReportList';
 
 function EmergencyPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [marker, setMarker] = useState<any>(null);
+  const [dangerMarker, setDangerMarker] = useState<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [circle, setCircle] = useState<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [infoWindow, setInfoWindow] = useState<any>(null);
+
   const mapRef = useRef(null);
   const { currentPosition } = useCurrentPosition();
   const { map } = useMap(
@@ -35,7 +36,7 @@ function EmergencyPage() {
     const { timestamp } = timeStamp.filter(item => item.id === Number(emergencyId))[0];
 
     // 이전에 있던 마커와 원, 윈도우를 지워야함
-    if (marker) marker.setMap(null);
+    if (dangerMarker) dangerMarker.setMap(null);
     if (circle) circle.setVisible(false);
     if (infoWindow) infoWindow.setMap(null);
 
@@ -43,7 +44,7 @@ function EmergencyPage() {
 
     const newMarker = generateMarker(map, lat, lng);
     newMarker.setMap(map);
-    setMarker(newMarker);
+    setDangerMarker(newMarker);
 
     const newInfoWindow = generateInfoWindow(map, lat, lng, convertDateFormat(timestamp));
     newInfoWindow.setMap(map);
@@ -57,7 +58,7 @@ function EmergencyPage() {
   return (
     <>
       <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
-      <BottomSheet />
+      <BottomSheet map={map} />
     </>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
 import useMap from '../hooks/useMap';
-import POSITIONS from '../constant/mockingPositions';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
@@ -31,27 +30,14 @@ function Home() {
     { latitude: 37.48209002, longitude: 126.93963778 },
   ]);
 
-  console.log(startPosition, endPosition);
-
   useEffect(() => {
     if (!currentPosition) return;
-
     // 현재 위치 마커 생성 및 추가
     generateMarker(
       map,
       currentPosition.coords.latitude,
       currentPosition.coords.longitude,
     );
-
-    // 위험 시설 마커 생성 및 추가
-    for (let i = 0; i < POSITIONS.length; i++) {
-      generateMarker(
-        map,
-        POSITIONS[i].lat,
-        POSITIONS[i].lng,
-        POSITIONS[i].title,
-      );
-    }
   }, [map]);
 
   useEffect(() => {
@@ -79,7 +65,7 @@ function Home() {
         style={{ width: '500px', height: '500px' }}
         ref={mapRef}
       />
-      <BottomSheet />
+      <BottomSheet map={map} />
     </>
   );
 }

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,0 +1,15 @@
+import { atom } from 'recoil';
+
+const filterState = atom<{[key:string] : boolean}>({
+  key: 'filterState',
+  default: {
+    cctv: false,
+    fireStation: false,
+    safetyFacility: false,
+    saftyCenter: false,
+    emergencyBell: false,
+    heatShelter: false
+  }
+});
+
+export default filterState;

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -75,7 +75,7 @@ export function generateInfoWindow(
     map,
     content,
     position: new Tmapv2.LatLng(lat, lng),
-    type: 1,
+    type: 2,
   });
   return infoWindow;
 }


### PR DESCRIPTION
### 개요

BottomSheet에서 위험지역 필터링을 할 수 있도록 기능을 추가했습니다.

### 작업 내용

- [x] 전역상태관리를 위해 Recoil 설정을 했습니다. (recoil 폴더 추가)
- [x] 임의로 모킹한 POSITION 데이터를 30개로 수정했습니다. (좌표는 랜덤 서울시위치로 지정했습니다.)
- [x] 인포 윈도우의 타입을 변경했습니다. (2 -> 1) (2에 오류가 있는 것 같아서 1로 변경했습니다)
- [x] 위험지역 마커 필터링 기능을 추가했습니다.

### 관련 이슈

Closes #46 

### 질문

필터링 버튼이 지금은 5개로 고정되어있어 Flex로 처리했습니다.
API 나오는대로 버튼 스타일 바꿔보겠습니다.

### 스크린샷 (선택 사항)