### PR TITLE
feat: 경로 탐색 페이지 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Home from './pages/Home';
 import EmergencyPage from './pages/EmergencyPage';
+import RouteExplorer from './pages/RouteExplorer';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <Home />
+    element: <Home />,
+  },
+  {
+    path: '/routes',
+    element: <RouteExplorer />,
   },
   {
     path: '/emergency',
@@ -17,16 +19,14 @@ const router = createBrowserRouter([
     children: [
       {
         path: ':emergencyId',
-        element: <EmergencyPage />
-      }
-    ]
-  }
+        element: <EmergencyPage />,
+      },
+    ],
+  },
 ]);
 
 function App() {
-  return (
-    <RouterProvider router={router} />
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -10,11 +10,18 @@ interface SearchBoxProps {
   placeholder: string;
   places: Place[];
   setPosition: React.Dispatch<React.SetStateAction<Coord>>;
+  // eslint-disable-next-line react/require-default-props
+  setName?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface ContainerProps {
-  setStartPosition: React.Dispatch<React.SetStateAction<Coord>>;
+  // eslint-disable-next-line react/require-default-props
+  setStartPosition?: React.Dispatch<React.SetStateAction<Coord>>;
   setEndPosition: React.Dispatch<React.SetStateAction<Coord>>;
+  // eslint-disable-next-line react/require-default-props
+  endName?: string;
+  // eslint-disable-next-line react/require-default-props
+  setEndName?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 function SearchBox({
@@ -23,6 +30,7 @@ function SearchBox({
   placeholder,
   places,
   setPosition,
+  setName,
 }: SearchBoxProps) {
   const { keyword, isSearching, selectedName } = searchState;
 
@@ -59,6 +67,9 @@ function SearchBox({
                     longitude: place.longitude,
                     latitude: place.latitude,
                   });
+                  if (setName) {
+                    setName(place.name);
+                  }
                 }}
               >
                 <div>{place.name}</div>
@@ -71,7 +82,12 @@ function SearchBox({
   );
 }
 
-function SearchContainer({ setStartPosition, setEndPosition }: ContainerProps) {
+function SearchContainer({
+  setStartPosition,
+  setEndPosition,
+  endName,
+  setEndName,
+}: ContainerProps) {
   const { currentPosition } = useCurrentPosition();
   const [startSearchState, setStartSearchState] = useState<SearchState>({
     keyword: '',
@@ -82,12 +98,13 @@ function SearchContainer({ setStartPosition, setEndPosition }: ContainerProps) {
   const [endSearchState, setEndSearchState] = useState<SearchState>({
     keyword: '',
     isSearching: false,
-    selectedName: '',
+    selectedName: endName || '',
   });
   const endPlaces = usePlaceSearch(endSearchState.keyword);
 
   // 혹시 나중에 출발지나 도착지를 현재 위치로 변경하는 기능을 추가할 때 유용할 것 같습니다.
   useEffect(() => {
+    if (!setStartPosition) return;
     updateAddressFromCurrentCoordinates(
       currentPosition,
       setStartSearchState,
@@ -98,19 +115,22 @@ function SearchContainer({ setStartPosition, setEndPosition }: ContainerProps) {
 
   return (
     <>
-      <SearchBox
-        searchState={startSearchState}
-        setSearchState={setStartSearchState}
-        placeholder="출발지를 입력하세요"
-        places={startPlaces}
-        setPosition={setStartPosition}
-      />
+      {setStartPosition && (
+        <SearchBox
+          searchState={startSearchState}
+          setSearchState={setStartSearchState}
+          placeholder="출발지를 입력하세요"
+          places={startPlaces}
+          setPosition={setStartPosition}
+        />
+      )}
       <SearchBox
         searchState={endSearchState}
         setSearchState={setEndSearchState}
         placeholder="도착지를 입력하세요"
         places={endPlaces}
         setPosition={setEndPosition}
+        setName={setEndName}
       />
     </>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import { generateMarker } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
 import BottomSheet from '../components/BottomSheet';
 import { Coord } from '../types/mapTypes';
+import { EXTRAPOSITIONS } from '../constant/mockingPositions';
 
 function Home() {
   const navigate = useNavigate();
@@ -23,13 +24,13 @@ function Home() {
     longitude: undefined,
   });
   const [endName, setEndName] = useState<string>('');
-  console.log(endName);
 
   const findRoute = () => {
     navigate('/routes', {
       state: { endPosition, endName },
     });
   };
+
   useEffect(() => {
     if (!currentPosition) return;
     // 현재 위치 마커 생성 및 추가
@@ -38,6 +39,16 @@ function Home() {
       currentPosition.coords.latitude,
       currentPosition.coords.longitude,
     );
+
+    // 위험 시설 마커 생성 및 추가
+    for (let i = 0; i < EXTRAPOSITIONS.length; i++) {
+      generateMarker(
+        map,
+        EXTRAPOSITIONS[i].lat,
+        EXTRAPOSITIONS[i].lng,
+        EXTRAPOSITIONS[i].title,
+      );
+    }
   }, [map]);
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,10 +23,12 @@ function Home() {
     latitude: undefined,
     longitude: undefined,
   });
+  const [endName, setEndName] = useState<string>('');
+  console.log(endName);
 
   const findRoute = () => {
     navigate('/routes', {
-      state: { endPosition },
+      state: { endPosition, endName },
     });
   };
   useEffect(() => {
@@ -52,7 +54,11 @@ function Home() {
 
   return (
     <>
-      <SearchContainer setEndPosition={setEndPosition} />
+      <SearchContainer
+        setEndPosition={setEndPosition}
+        endName={endName}
+        setEndName={setEndName}
+      />
       <button type="button" onClick={findRoute}>
         길찾기
       </button>

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -3,10 +3,11 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import { drawRoute } from '../utils/mapUtils';
+import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/SearchInput';
 import BottomSheet from '../components/BottomSheet';
 import { Coord } from '../types/mapTypes';
+import { EXTRAPOSITIONS } from '../constant/mockingPositions';
 
 function RouteExplorer() {
   const { state } = useLocation();
@@ -39,26 +40,26 @@ function RouteExplorer() {
     }
   }, [state]);
 
-  // useEffect(() => {
-  //   if (!currentPosition) return;
+  useEffect(() => {
+    if (!currentPosition) return;
 
-  //   // 현재 위치 마커 생성 및 추가
-  //   generateMarker(
-  //     map,
-  //     currentPosition.coords.latitude,
-  //     currentPosition.coords.longitude,
-  //   );
+    // 현재 위치 마커 생성 및 추가
+    generateMarker(
+      map,
+      currentPosition.coords.latitude,
+      currentPosition.coords.longitude,
+    );
 
-  //   // 위험 시설 마커 생성 및 추가
-  //   for (let i = 0; i < POSITIONS.length; i++) {
-  //     generateMarker(
-  //       map,
-  //       POSITIONS[i].lat,
-  //       POSITIONS[i].lng,
-  //       POSITIONS[i].title,
-  //     );
-  //   }
-  // }, [map]);
+    // 위험 시설 마커 생성 및 추가
+    for (let i = 0; i < EXTRAPOSITIONS.length; i++) {
+      generateMarker(
+        map,
+        EXTRAPOSITIONS[i].lat,
+        EXTRAPOSITIONS[i].lng,
+        EXTRAPOSITIONS[i].title,
+      );
+    }
+  }, [map]);
 
   useEffect(() => {
     if (!map) return;

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -85,6 +85,7 @@ function RouteExplorer() {
       <SearchContainer
         setStartPosition={setStartPosition}
         setEndPosition={setEndPosition}
+        endName={state?.endName}
       />
       <div
         id="map_div"


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
홈이 아닌 '/routes' 페이지에서 경로를 보여주도록 경로 탐색 페이지를 만들었어요
작동 순서
1. 홈에서 도착지를 입력 후 길찾기 버튼을 클릭
2. '/routes' 페이지로 이동, endPosition, endName을 state으로 전달받음
3. 경로 보여줌

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->
- [x] 경로 탐색 페이지 분리
- [x] 홈에서 입력 받은 도착지를 '/routes'페이지로 넘기기 위해 SearchInput의 props를 추가했습니다. 그런데 선택적으로 사용하는 타입으로 주다 보니 나중에 헷갈릴 것 같아 recoil로 관리할까 생각중입니다. 


### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #30 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- endName을 recoil로 관리하는 것에 대해 어떻게 생각하시는지 알고 싶어요!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
