### PR TITLE
refactor : emergencyPage에서 비즈니스 로직 분리

### DIFF
--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -3,13 +3,10 @@ import { BottomSheetContent, Wrapper } from './style';
 import BottomSheetHeader from '../BottomSheetHeader';
 import Content from '../BottomSheetContents';
 import useBottomSheet from '../../hooks/useBottomSheet';
-import { EXTRAPOSITIONS } from '../../constant/mockingPositions';
-import useFilteringMarker from '../../hooks/useFilteringMarker';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function BottomSheet({map}:any) {
+function BottomSheet() {
   const { sheet, content } = useBottomSheet();
-  useFilteringMarker(map, EXTRAPOSITIONS);
 
   return (
     <Wrapper ref={sheet}>

--- a/src/components/BottomSheetContents/index.tsx
+++ b/src/components/BottomSheetContents/index.tsx
@@ -21,6 +21,7 @@ function Content(){
   };
 
   useEffect(() => {
+    // 필터 값을 전부 isChecked로 맞춘다.
     setCurrentFilters(Object.fromEntries(Object.entries(currentFilters).map(([key]) => [key, isChecked])));
   }, [isChecked]);
 
@@ -28,15 +29,15 @@ function Content(){
     switch(input) {
       case 'cctv':
         return 'CCTV';
-      case 'safetyFacility':
+      case 'safetyfacility':
         return '안전시설';
-      case 'fireStation':
+      case 'firestation':
         return '소방서';
-      case 'heatShelter':
+      case 'heatshelter':
         return '무더위 쉼터';
-      case 'saftyCenter':
+      case 'saftycenter':
         return '안전센터';
-      case 'emergencyBell':
+      case 'emergencybell':
         return '비상벨';
       default:
         return '알 수 없는 입력값';

--- a/src/constant/mockingPositions.ts
+++ b/src/constant/mockingPositions.ts
@@ -9,12 +9,12 @@ export interface MockedPositionType {
 }
 
 export const EXTRAPOSITIONS: MockedPositionType[] = [{
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.64962573412779, 127.11504591714298),
   'lat': 37.64962573412779,
   'lng': 127.11504591714298
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.68072864628185, 126.90181668699964),
   'lat': 37.68072864628185,
   'lng': 126.90181668699964
@@ -24,27 +24,27 @@ export const EXTRAPOSITIONS: MockedPositionType[] = [{
   'lat': 37.55450254974857,
   'lng': 127.01393249069437
 }, {
-  'title': 'heatShelter',
+  'title': 'heatshelter',
   'latlng': new Tmapv2.LatLng(37.44109400943535, 126.93263715735526),
   'lat': 37.44109400943535,
   'lng': 126.93263715735526
 }, {
-  'title': 'safetyFacility',
+  'title': 'safetyfacility',
   'latlng': new Tmapv2.LatLng(37.66259829457774, 126.8083975475223),
   'lat': 37.66259829457774,
   'lng': 126.8083975475223
 }, {
-  'title': 'safetyFacility',
+  'title': 'safetyfacility',
   'latlng': new Tmapv2.LatLng(37.60695791324267, 126.79316209701774),
   'lat': 37.60695791324267,
   'lng': 126.79316209701774
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.65305891174702, 126.76806290751455),
   'lat': 37.65305891174702,
   'lng': 126.76806290751455
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.573619452071085, 127.01597452833518),
   'lat': 37.573619452071085,
   'lng': 127.01597452833518
@@ -54,12 +54,12 @@ export const EXTRAPOSITIONS: MockedPositionType[] = [{
   'lat': 37.59913063423765,
   'lng': 127.10149578560635
 }, {
-  'title': 'safetyFacility',
+  'title': 'safetyfacility',
   'latlng': new Tmapv2.LatLng(37.679084014027424, 127.15896446310936),
   'lat': 37.679084014027424,
   'lng': 127.15896446310936
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.49845463160961, 126.94007376296142),
   'lat': 37.49845463160961,
   'lng': 126.94007376296142
@@ -69,82 +69,82 @@ export const EXTRAPOSITIONS: MockedPositionType[] = [{
   'lat': 37.59897664847852,
   'lng': 127.16406222426656
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.505337052136255, 127.10747391682135),
   'lat': 37.505337052136255,
   'lng': 127.10747391682135
 }, {
-  'title': 'heatShelter',
+  'title': 'heatshelter',
   'latlng': new Tmapv2.LatLng(37.428676694040455, 126.97636994666635),
   'lat': 37.428676694040455,
   'lng': 126.97636994666635
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.68567659030394, 127.08057259433093),
   'lat': 37.68567659030394,
   'lng': 127.08057259433093
 }, {
-  'title': 'safetyFacility',
+  'title': 'safetyfacility',
   'latlng': new Tmapv2.LatLng(37.67916484813188, 126.87580869551581),
   'lat': 37.67916484813188,
   'lng': 126.87580869551581
 }, {
-  'title': 'heatShelter',
+  'title': 'heatshelter',
   'latlng': new Tmapv2.LatLng(37.44126035414257, 127.0422893958011),
   'lat': 37.44126035414257,
   'lng': 127.0422893958011
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.56636858041499, 127.07219489981215),
   'lat': 37.56636858041499,
   'lng': 127.07219489981215
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.63885286489996, 127.07580704421247),
   'lat': 37.63885286489996,
   'lng': 127.07580704421247
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.54914572187157, 126.94933302584089),
   'lat': 37.54914572187157,
   'lng': 126.94933302584089
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.64269276933789, 127.09306797623269),
   'lat': 37.64269276933789,
   'lng': 127.09306797623269
 }, {
-  'title': 'saftyCenter',
+  'title': 'saftycenter',
   'latlng': new Tmapv2.LatLng(37.58359991403163, 126.93638213559551),
   'lat': 37.58359991403163,
   'lng': 126.93638213559551
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.520572834739966, 127.02923327689213),
   'lat': 37.520572834739966,
   'lng': 127.02923327689213
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.56462824570889, 126.91616304904088),
   'lat': 37.56462824570889,
   'lng': 126.91616304904088
 }, {
-  'title': 'emergencyBell',
+  'title': 'emergencybell',
   'latlng': new Tmapv2.LatLng(37.53668800482912, 127.02166820551248),
   'lat': 37.53668800482912,
   'lng': 127.02166820551248
 }, {
-  'title': 'saftyCenter',
+  'title': 'saftycenter',
   'latlng': new Tmapv2.LatLng(37.447135955201055, 127.08560447109214),
   'lat': 37.447135955201055,
   'lng': 127.08560447109214
 }, {
-  'title': 'safetyFacility',
+  'title': 'safetyfacility',
   'latlng': new Tmapv2.LatLng(37.56582802537122, 127.07335943054802),
   'lat': 37.56582802537122,
   'lng': 127.07335943054802
 }, {
-  'title': 'fireStation',
+  'title': 'firestation',
   'latlng': new Tmapv2.LatLng(37.539428938972264, 127.00580491374272),
   'lat': 37.539428938972264,
   'lng': 127.00580491374272
@@ -160,4 +160,4 @@ export const EXTRAPOSITIONS: MockedPositionType[] = [{
   'lng': 126.79833336814202
 }];
 
-export const POSITIONTITLE = [ 'cctv', 'fireStation', 'safetyFacility', 'saftyCenter', 'emergencyBell', 'heatShelter'];
+export const POSITIONTITLE = [ 'cctv', 'firestation', 'safetyfacility', 'saftycenter', 'emergencybell', 'heatshelter'];

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -33,6 +33,7 @@ export default function useBottomSheet() {
   });
 
   const handleEventEnd = () => {
+    if(!sheet.current) return;
     document.body.style.overflowY = 'auto';
     const { clickMove } = metrics.current;
     const currentSheetY = sheet.current!.getBoundingClientRect().y;
@@ -61,6 +62,7 @@ export default function useBottomSheet() {
   };
 
   const handleEventStart = (clientY: number) => {
+    if(!sheet.current) return;
     const { clickStart } = metrics.current;
     clickStart.sheetY = sheet.current!.getBoundingClientRect().y;
     clickStart.clickY = clientY;
@@ -84,6 +86,7 @@ export default function useBottomSheet() {
   };
 
   const handleEventMove = (currentPosition: number) => {
+    if(!sheet.current) return;
     const { clickStart, clickMove } = metrics.current;
 
     if (clickMove.prevClickY === undefined) {

--- a/src/hooks/useEmergencyMarker.ts
+++ b/src/hooks/useEmergencyMarker.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import timeStamp from '../constant/mockingTimeStamp';
+import {
+  generateMarker,
+  drawCircle,
+  generateInfoWindow,
+  setCenter,
+} from '../utils/mapUtils';
+import { convertDateFormat } from '../components/ReportList';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function useEmergencyMarker(map: any, emergencyId: string | undefined) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [dangerMarker, setDangerMarker] = useState<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [circle, setCircle] = useState<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [infoWindow, setInfoWindow] = useState<any>(null);
+
+  useEffect(() => {
+    if (!map || !emergencyId) return;
+    const { lat, lng } = timeStamp.filter(item => item.id === Number(emergencyId)).map(item => ({ lat: item.lat, lng: item.lng }))[0];
+    const { timestamp } = timeStamp.filter(item => item.id === Number(emergencyId))[0];
+
+    // 이전에 있던 마커와 원, 윈도우를 지워야함
+    if (dangerMarker) dangerMarker.setMap(null);
+    if (circle) circle.setVisible(false);
+    if (infoWindow) infoWindow.setMap(null);
+
+    setCenter(map, lat, lng);
+
+    const newMarker = generateMarker(map, lat, lng);
+    newMarker.setMap(map);
+    setDangerMarker(newMarker);
+
+    const newInfoWindow = generateInfoWindow(map, lat, lng, convertDateFormat(timestamp));
+    newInfoWindow.setMap(map);
+    setInfoWindow(newInfoWindow);
+
+    const newCircle = drawCircle(map, lat, lng);
+    newCircle.setMap(map);
+    setCircle(newCircle);
+  }, [map, emergencyId]);
+}
+
+export default useEmergencyMarker;

--- a/src/hooks/useFilteringMarker.ts
+++ b/src/hooks/useFilteringMarker.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { MockedPositionType } from '../constant/mockingPositions';
+import { EXTRAPOSITIONS } from '../constant/mockingPositions';
 import { generateMarker } from '../utils/mapUtils';
 import filterState from '../recoil/atoms';
 
@@ -12,12 +12,13 @@ interface FacilityMarkerType {
   }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function useFilteringMarker(map:any, facilityData: MockedPositionType[]) {
+function useFilteringMarker(map:any) {
   const [facilityMarker, setFacilityMarker] = useState<FacilityMarkerType[]>([]);
   const filterValue = useRecoilValue(filterState);
 
   useEffect(() => {
-    const filteredMarkerData = facilityData.map(position => {
+    // TODO : 여기 API로 모든 facility를 불러오는 로직이 필요합니다.
+    const filteredMarkerData = EXTRAPOSITIONS.map(position => {
       const marker = generateMarker(map, position.lat, position.lng, position.title);
       return {
         title: position.title,
@@ -26,7 +27,7 @@ function useFilteringMarker(map:any, facilityData: MockedPositionType[]) {
       };
     });
     setFacilityMarker(filteredMarkerData);
-  }, [map, facilityData]);
+  }, [map]);
 
   // 필터링값을 확인하고, facilityMarker 데이터를 업데이트함
   useEffect(() => {

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -1,27 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import useMap from '../hooks/useMap';
-import {
-  generateMarker,
-  drawCircle,
-  generateInfoWindow,
-  setCenter,
-} from '../utils/mapUtils';
-
 import useCurrentPosition from '../hooks/useCurruntPosition';
-import BottomSheet from '../components/BottomSheet';
-import timeStamp from '../constant/mockingTimeStamp';
-import { convertDateFormat } from '../components/ReportList';
-import useFilteringMarker from '../hooks/useFilteringMarker';
+import useEmergencyMarker from '../hooks/useEmergencyMarker';
+// import useFilteringMarker from '../hooks/useFilteringMarkerWithAPI';
 
 function EmergencyPage() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [dangerMarker, setDangerMarker] = useState<any>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [circle, setCircle] = useState<any>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [infoWindow, setInfoWindow] = useState<any>(null);
-
   const mapRef = useRef(null);
   const { currentPosition } = useCurrentPosition();
   const { map } = useMap(
@@ -30,38 +14,11 @@ function EmergencyPage() {
     currentPosition?.coords.longitude,
   );
   const { emergencyId } = useParams();
-  useFilteringMarker(map);
-
-  useEffect(() => {
-    if (!map) return;
-    const { lat, lng } = timeStamp.filter(item => item.id === Number(emergencyId)).map(item => ({ lat: item.lat, lng: item.lng }))[0];
-    const { timestamp } = timeStamp.filter(item => item.id === Number(emergencyId))[0];
-
-    // 이전에 있던 마커와 원, 윈도우를 지워야함
-    if (dangerMarker) dangerMarker.setMap(null);
-    if (circle) circle.setVisible(false);
-    if (infoWindow) infoWindow.setMap(null);
-
-    setCenter(map, lat, lng);
-
-    const newMarker = generateMarker(map, lat, lng);
-    newMarker.setMap(map);
-    setDangerMarker(newMarker);
-
-    const newInfoWindow = generateInfoWindow(map, lat, lng, convertDateFormat(timestamp));
-    newInfoWindow.setMap(map);
-    setInfoWindow(newInfoWindow);
-
-    const newCircle = drawCircle(map, lat, lng);
-    newCircle.setMap(map);
-    setCircle(newCircle);
-  }, [map, emergencyId]);
+  useEmergencyMarker(map, emergencyId);
+  // useFilteringMarker(map);
 
   return (
-    <>
-      <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
-      <BottomSheet />
-    </>
+    <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
   );
 }
 

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -12,6 +12,7 @@ import useCurrentPosition from '../hooks/useCurruntPosition';
 import BottomSheet from '../components/BottomSheet';
 import timeStamp from '../constant/mockingTimeStamp';
 import { convertDateFormat } from '../components/ReportList';
+import useFilteringMarker from '../hooks/useFilteringMarker';
 
 function EmergencyPage() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -29,6 +30,7 @@ function EmergencyPage() {
     currentPosition?.coords.longitude,
   );
   const { emergencyId } = useParams();
+  useFilteringMarker(map);
 
   useEffect(() => {
     if (!map) return;
@@ -58,7 +60,7 @@ function EmergencyPage() {
   return (
     <>
       <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
-      <BottomSheet map={map} />
+      <BottomSheet />
     </>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import SearchContainer from '../components/SearchInput';
 import BottomSheet from '../components/BottomSheet';
 import { Coord } from '../types/mapTypes';
 import { EXTRAPOSITIONS } from '../constant/mockingPositions';
+import useFilteringMarker from '../hooks/useFilteringMarker';
 
 function Home() {
   const navigate = useNavigate();
@@ -18,7 +19,7 @@ function Home() {
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
-
+  useFilteringMarker(map);
   const [endPosition, setEndPosition] = useState<Coord>({
     latitude: undefined,
     longitude: undefined,
@@ -66,7 +67,7 @@ function Home() {
         style={{ width: '500px', height: '500px' }}
         ref={mapRef}
       />
-      <BottomSheet map={map} />
+      <BottomSheet />
     </>
   );
 }

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -9,11 +9,11 @@ export const { Tmapv2 } = window;
 
 export type FacilitiesType =
   | 'cctv'
-  | 'fireStation'
-  | 'safetyFacility'
-  | 'saftyCenter'
-  | 'emergencyBell'
-  | 'heatShelter'
+  | 'firestation'
+  | 'safetyfacility'
+  | 'saftycenter'
+  | 'emergencybell'
+  | 'heatshelter'
   | 'way';
 
 export interface SearchState {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -24,15 +24,15 @@ const getImageSrc = (facilities?: FacilitiesType) => {
   switch (facilities) {
     case 'cctv':
       return cctv;
-    case 'fireStation':
+    case 'firestation':
       return fireStation;
-    case 'safetyFacility':
+    case 'safetyfacility':
       return safetFacility;
-    case 'saftyCenter':
+    case 'saftycenter':
       return safetCenter;
-    case 'emergencyBell':
+    case 'emergencybell':
       return emergencyBell;
-    case 'heatShelter':
+    case 'heatshelter':
       return heatShelter;
     default:
       return location;


### PR DESCRIPTION
### 개요

emergencyPage에서 비즈니스 로직을 커스텀훅으로 분해하여 렌더에만 집중하도록 했습니다.

### 작업 내용

- [x] 비즈니스로직 useEmergencyMarker.ts 로 분리
- [x] useBottomSheet null 에러 해결
- [x] 모킹 데이터의 title을 수정

### 관련 이슈

Closes #49
Closes #54 

### 질문

API가 지금 CORS 에러를 내고 있는 상태라 useFilteringMarker 훅에대한 수정은
고쳐질때까지 미뤄야할 것 같습니다.

그래도 할 수 있는 것들을 찾아서 해보겠습니다.

### 스크린샷 (선택 사항)

