### PR TITLE
design: 모바일 사이즈 공통 Wrapper 적용

### DIFF
--- a/public/reset.css
+++ b/public/reset.css
@@ -105,6 +105,9 @@ nav,
 section {
   display: block;
 }
+* {
+  box-sizing: border-box;
+}
 body {
   line-height: 1;
   color: #2e2d2c;

--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -1,14 +1,20 @@
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
-import { BOTTOM_SHEET_DEFAULT_HEIGHT, BOTTOM_SHEET_HEIGHT } from '../../constant/bottomSheetPosition';
+import {
+  BOTTOM_SHEET_DEFAULT_HEIGHT,
+  BOTTOM_SHEET_HEIGHT,
+} from '../../constant/bottomSheetPosition';
 
 export const Wrapper = styled(motion.div)`
+  width: 360px;
   display: flex;
   flex-direction: column;
-  
+
   position: fixed;
   z-index: 1;
-  top: calc(100% - ${BOTTOM_SHEET_DEFAULT_HEIGHT}px); /*시트가 얼마나 높이 위치할지*/
+  top: calc(
+    100% - ${BOTTOM_SHEET_DEFAULT_HEIGHT}px
+  ); /*시트가 얼마나 높이 위치할지*/
   left: 0;
   right: 0;
 

--- a/src/components/BottomSheetContents/index.tsx
+++ b/src/components/BottomSheetContents/index.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { POSITIONTITLE } from '../../constant/mockingPositions';
-import { FacilityButton, ButtonWrapper, Wrapper, ReportBtn, Label, ReportListWrapper} from './style';
+import {
+  FacilityButton,
+  ButtonWrapper,
+  Wrapper,
+  ReportBtn,
+  Label,
+  ReportListWrapper,
+} from './style';
 import ReportList from '../ReportList';
 import filterState from '../../recoil/atoms';
 
-function Content(){
+function Content() {
   const [isChecked, setIsChecked] = useState(false);
   const [currentFilters, setCurrentFilters] = useRecoilState(filterState);
 
-  const handleButtonClick = (title:string) => {
+  const handleButtonClick = (title: string) => {
     setCurrentFilters({
       ...currentFilters,
       [title]: !currentFilters[title],
@@ -22,11 +29,15 @@ function Content(){
 
   useEffect(() => {
     // 필터 값을 전부 isChecked로 맞춘다.
-    setCurrentFilters(Object.fromEntries(Object.entries(currentFilters).map(([key]) => [key, isChecked])));
+    setCurrentFilters(
+      Object.fromEntries(
+        Object.entries(currentFilters).map(([key]) => [key, isChecked]),
+      ),
+    );
   }, [isChecked]);
 
   function traslateToKorean(input: string): string {
-    switch(input) {
+    switch (input) {
       case 'cctv':
         return 'CCTV';
       case 'safetyfacility':
@@ -44,7 +55,7 @@ function Content(){
     }
   }
 
-  return(
+  return (
     <>
       <Wrapper>
         <Label htmlFor="safetyCheckbox">
@@ -62,13 +73,13 @@ function Content(){
               key={`facilityBtn_${position}`}
               $isClicked={currentFilters[position]}
               onMouseDown={() => handleButtonClick(position)}
-              type='button'
+              type="button"
             >
-              {(traslateToKorean(position))}
+              {traslateToKorean(position)}
             </FacilityButton>
           ))}
         </ButtonWrapper>
-        <ReportBtn type='button'>1시간 내 긴급신고</ReportBtn>
+        <ReportBtn type="button">1시간 내 긴급신고</ReportBtn>
       </Wrapper>
       <ReportListWrapper>
         <ReportList />

--- a/src/components/BottomSheetContents/style.ts
+++ b/src/components/BottomSheetContents/style.ts
@@ -1,48 +1,52 @@
 import styled from 'styled-components';
 
 interface FacilityButtonProps {
-    $isClicked: boolean;
+  $isClicked: boolean;
 }
 
 export const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 140px;
-    z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: fit-content;
+  z-index: 1;
 `;
 
 export const Label = styled.label`
-    padding-left: 8px;
+  margin-left: 1rem;
 `;
 
 export const ButtonWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    padding: 0px 8px
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 1rem;
 `;
 
 export const FacilityButton = styled.button<FacilityButtonProps>`
-    padding: 8px 14px;
-    border: none;
-    border-radius: 24px;
-    background-color: ${(props) => props.$isClicked ? '#F9ECD4' : '#F4F4F4'};
-    font-size: 15px;
-    cursor: pointer;
+  width: fit-content;
+  height: 2rem;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 2rem;
+  background-color: ${(props) => (props.$isClicked ? '#F9ECD4' : '#F4F4F4')};
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
 `;
 
 export const ReportBtn = styled.button`
-    width: 100%;
-    padding: 16px 0px;
-    border: none;
-    color: #fff;
-    background-color: #FF7757;
-    font-size: 16px;
-    font-weight: 600;
-    cursor: pointer;
+  width: 100%;
+  padding: 16px 0px;
+  border: none;
+  color: #fff;
+  background-color: #ff7757;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
 `;
 
 export const ReportListWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 `;

--- a/src/components/BottomSheetHeader/style.ts
+++ b/src/components/BottomSheetHeader/style.ts
@@ -1,19 +1,16 @@
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
-  height : 24px;
-  /* border-top-left-radius: 12px; */
-  /* border-bottom-right-radius: 12px; */
-  position: relative; 
-  padding-top: 24px;
-  padding-bottom: 12px;
+  height: 2rem;
+  position: relative;
+  margin-top: 14px;
   cursor: pointer;
 `;
 
 export const Handle = styled.div`
-  width: 40px;
+  width: 2.5rem;
   height: 4px;
   border-radius: 2px;
-  background-color: #DEE2E6;
+  background-color: #dee2e6;
   margin: auto;
 `;

--- a/src/components/RouteCarousel/style.ts
+++ b/src/components/RouteCarousel/style.ts
@@ -10,6 +10,7 @@ export const Carousel = styled.div`
   justify-content: center;
   padding-inline: 1rem;
   box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
+  background-color: #ffffff;
   position: fixed;
   bottom: 1.2rem;
   left: 1.25rem;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -3,7 +3,7 @@ import usePlaceSearch from '../../hooks/usePlaceSearch';
 import useCurrentPosition from '../../hooks/useCurruntPosition';
 import { updateAddressFromCurrentCoordinates } from '../../utils/mapUtils';
 import { Coord, SearchState, Place } from '../../types/mapTypes';
-import { SearchWrapper } from './style';
+import { SearchWrapper, SearchInput } from './style';
 
 interface SearchBoxProps {
   searchState: SearchState;
@@ -44,7 +44,7 @@ function SearchBox({
   };
 
   return (
-    <>
+    <SearchInput>
       <input
         type="text"
         value={isSearching ? keyword : selectedName}
@@ -79,7 +79,7 @@ function SearchBox({
           ))}
         </ul>
       )}
-    </>
+    </SearchInput>
   );
 }
 

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -3,7 +3,12 @@ import usePlaceSearch from '../../hooks/usePlaceSearch';
 import useCurrentPosition from '../../hooks/useCurruntPosition';
 import { updateAddressFromCurrentCoordinates } from '../../utils/mapUtils';
 import { Coord, SearchState, Place } from '../../types/mapTypes';
-import { SearchWrapper, SearchInput } from './style';
+import {
+  SearchWrapper,
+  SearchInput,
+  SearchResultContainer,
+  SearchResultList,
+} from './style';
 
 interface SearchBoxProps {
   searchState: SearchState;
@@ -52,32 +57,30 @@ function SearchBox({
         placeholder={placeholder}
       />
       {isSearching && (
-        <ul>
+        <SearchResultContainer>
           {places.map((place, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <li key={index}>
-              <button
-                type="button"
-                onClick={() => {
-                  setSearchState({
-                    ...searchState,
-                    isSearching: false,
-                    selectedName: place.name,
-                  });
-                  setPosition({
-                    longitude: place.longitude,
-                    latitude: place.latitude,
-                  });
-                  if (setName) {
-                    setName(place.name);
-                  }
-                }}
-              >
-                <div>{place.name}</div>
-              </button>
-            </li>
+            <SearchResultList
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              onClick={() => {
+                setSearchState({
+                  ...searchState,
+                  isSearching: false,
+                  selectedName: place.name,
+                });
+                setPosition({
+                  longitude: place.longitude,
+                  latitude: place.latitude,
+                });
+                if (setName) {
+                  setName(place.name);
+                }
+              }}
+            >
+              {place.name}
+            </SearchResultList>
           ))}
-        </ul>
+        </SearchResultContainer>
       )}
     </SearchInput>
   );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import usePlaceSearch from '../hooks/usePlaceSearch';
-import useCurrentPosition from '../hooks/useCurruntPosition';
-import { updateAddressFromCurrentCoordinates } from '../utils/mapUtils';
-import { Coord, SearchState, Place } from '../types/mapTypes';
+import usePlaceSearch from '../../hooks/usePlaceSearch';
+import useCurrentPosition from '../../hooks/useCurruntPosition';
+import { updateAddressFromCurrentCoordinates } from '../../utils/mapUtils';
+import { Coord, SearchState, Place } from '../../types/mapTypes';
+import { SearchWrapper } from './style';
 
 interface SearchBoxProps {
   searchState: SearchState;
@@ -114,7 +115,7 @@ function SearchContainer({
   }, [currentPosition]);
 
   return (
-    <>
+    <SearchWrapper>
       {setStartPosition && (
         <SearchBox
           searchState={startSearchState}
@@ -132,7 +133,7 @@ function SearchContainer({
         setPosition={setEndPosition}
         setName={setEndName}
       />
-    </>
+    </SearchWrapper>
   );
 }
 

--- a/src/components/Search/style.ts
+++ b/src/components/Search/style.ts
@@ -12,6 +12,7 @@ export const SearchWrapper = styled.div`
 `;
 
 export const SearchInput = styled.div`
+  position: relative;
   input {
     width: 340px;
     height: 2.5rem;
@@ -27,5 +28,32 @@ export const SearchInput = styled.div`
 
   input::placeholder {
     color: #bcbab6;
+  }
+`;
+export const SearchResultContainer = styled.ul`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%; /* 부모 요소와 같은 너비로 설정 */
+  display: flex;
+  flex-direction: column;
+  z-index: 1;
+  background-color: #ffffff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+export const SearchResultList = styled.li`
+  display: flex;
+  align-items: center;
+  padding-left: 1rem;
+  height: 44px;
+  line-height: 1.5;
+  font-size: 13px;
+  border-bottom: 1px solid #f4f4f4;
+
+  &:hover,
+  &:active {
+    background-color: #fcf4e7;
+    cursor: pointer;
   }
 `;

--- a/src/components/Search/style.ts
+++ b/src/components/Search/style.ts
@@ -1,0 +1,6 @@
+// Wrapper/styles.ts
+import styled from 'styled-components';
+
+export const SearchWrapper = styled.div``;
+
+export const SearchBox = styled.div``;

--- a/src/components/Search/style.ts
+++ b/src/components/Search/style.ts
@@ -1,6 +1,31 @@
 // Wrapper/styles.ts
 import styled from 'styled-components';
 
-export const SearchWrapper = styled.div``;
+export const SearchWrapper = styled.div`
+  width: 100%;
+  height: 9rem;
+  background-color: #ffffff;
+  padding: 2rem 10px 1rem 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
 
-export const SearchBox = styled.div``;
+export const SearchInput = styled.div`
+  input {
+    width: 340px;
+    height: 2.5rem;
+    border-radius: 1.5rem;
+    border: 1px solid #868581;
+    padding: 0.8rem 1rem;
+  }
+
+  input:focus {
+    outline: none;
+    border: 3px solid #868581;
+  }
+
+  input::placeholder {
+    color: #bcbab6;
+  }
+`;

--- a/src/components/common/Wrapper/index.tsx
+++ b/src/components/common/Wrapper/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { WrapperContainer } from './style';
+
+interface WrapperProps {
+  children: React.ReactNode;
+}
+
+function Wrapper({ children }: WrapperProps) {
+  return <WrapperContainer>{children}</WrapperContainer>;
+}
+
+export default Wrapper;

--- a/src/components/common/Wrapper/style.ts
+++ b/src/components/common/Wrapper/style.ts
@@ -1,0 +1,34 @@
+// Wrapper/styles.ts
+import styled from 'styled-components';
+
+export const WrapperContainer = styled.div`
+  /* 공통 스타일링 */
+  max-width: 360px;
+  background-color: yellow;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  #map_div {
+    /* position: fixed;
+    top: 0;
+    left: 0; */
+    width: 360px;
+    height: 100%;
+  }
+`;
+
+export const MobileWrapperContainer = styled(WrapperContainer)`
+  /* 모바일 화면에 대한 스타일링 */
+  @media (min-width: 768px) {
+    display: none;
+  }
+`;
+
+export const DesktopWrapperContainer = styled(WrapperContainer)`
+  /* 데스크톱 화면에 대한 스타일링 */
+  @media (max-width: 767px) {
+    display: none;
+  }
+`;

--- a/src/components/common/Wrapper/style.ts
+++ b/src/components/common/Wrapper/style.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 export const WrapperContainer = styled.div`
   /* 공통 스타일링 */
   max-width: 360px;
-  background-color: yellow;
+  /* background-color: yellow; */
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/constant/bottomSheetPosition.ts
+++ b/src/constant/bottomSheetPosition.ts
@@ -1,8 +1,8 @@
 // 바텀 시트가 최대로 올라갔을 때 Y값
-export const MIN_Y = 100;
+export const MIN_Y = 80;
 // 바텀 시트가 최소로 내려갔을 때 Y값
 export const MAX_Y = window.innerHeight - 200;
 // 바텀 시트가 아래에 있을 때 높이
-export const BOTTOM_SHEET_DEFAULT_HEIGHT = 200;
+export const BOTTOM_SHEET_DEFAULT_HEIGHT = 222;
 // 바텀 시트의 높이
 export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y;

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -10,12 +10,12 @@ function useMap(
   const [map, setMap] = useState<any>(null);
 
   useEffect(() => {
-    if(map) return;
+    if (map) return;
     if (!lat || !lng || !containerRef.current) return;
     if (containerRef.current) {
       const options = {
         center: new Tmapv2.LatLng(lat, lng),
-        zoom: 15,
+        zoom: 14,
       };
       const newMap = new Tmapv2.Map(containerRef.current, options);
       setMap(newMap);

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -20,7 +20,7 @@ function EmergencyPage() {
 
   return (
     <WrapperContainer>
-      <div id="map" ref={mapRef} />
+      <div id="map_div" ref={mapRef} />
     </WrapperContainer>
   );
 }

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import useEmergencyMarker from '../hooks/useEmergencyMarker';
+import { WrapperContainer } from '../components/common/Wrapper/style';
 // import useFilteringMarker from '../hooks/useFilteringMarkerWithAPI';
 
 function EmergencyPage() {
@@ -18,7 +19,9 @@ function EmergencyPage() {
   // useFilteringMarker(map);
 
   return (
-    <div id="map" style={{ width: '500px', height: '500px' }} ref={mapRef} />
+    <WrapperContainer>
+      <div id="map" ref={mapRef} />
+    </WrapperContainer>
   );
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,11 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker } from '../utils/mapUtils';
-import SearchContainer from '../components/SearchInput';
+import SearchContainer from '../components/Search';
 import BottomSheet from '../components/BottomSheet';
 import { Coord } from '../types/mapTypes';
 import { EXTRAPOSITIONS } from '../constant/mockingPositions';
 import useFilteringMarker from '../hooks/useFilteringMarker';
+import { WrapperContainer } from '../components/common/Wrapper/style';
 
 function Home() {
   const navigate = useNavigate();
@@ -53,7 +54,7 @@ function Home() {
   }, [map]);
 
   return (
-    <>
+    <WrapperContainer>
       <SearchContainer
         setEndPosition={setEndPosition}
         endName={endName}
@@ -62,13 +63,9 @@ function Home() {
       <button type="button" onClick={findRoute}>
         길찾기
       </button>
-      <div
-        id="map_div"
-        style={{ width: '500px', height: '500px' }}
-        ref={mapRef}
-      />
+      <div id="map_div" ref={mapRef} />
       <BottomSheet />
-    </>
+    </WrapperContainer>
   );
 }
 

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -4,9 +4,10 @@ import { useLocation } from 'react-router-dom';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
-import SearchContainer from '../components/SearchInput';
+import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
+import Wrapper from '../components/common/Wrapper';
 
 function RouteExplorer() {
   const { state } = useLocation();
@@ -74,21 +75,19 @@ function RouteExplorer() {
   }, [map, startPosition, endPosition, waypoints]);
 
   return (
-    <>
+    <Wrapper>
       <SearchContainer
         setStartPosition={setStartPosition}
         setEndPosition={setEndPosition}
         endName={state?.endName}
       />
-      <div
-        id="map_div"
-        style={{ width: '500px', height: '500px' }}
-        ref={mapRef}
-      />
+
+      <div id="map_div" ref={mapRef} />
+
       {routeInfo && (
         <RouteCarousel routeInfo={routeInfo} waypoints={waypoints} />
       )}
-    </>
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
모바일 사이즈에 맞추기 위해 공통 Wrapper를 적용했습니다. 

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 모든 페이지를 WrapperContainer로 감싸주었어요. 아직 가운데에 위치시키지는 않았습니다. width는 360px로 맞췄는데 기본 100%로 하고 max-width를 설정하는게 좋을 것 같아요
- [x] 나머지 컴포넌트의 사이즈들을 모바일에 맞춰 수정했어요. 
- [x] 장소 검색 리스트 UI 구현 

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #58 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- BottomSheet 크기 수정하면서 포지션 관련 변수들을 제가 건드렸는데 이해가 부족해서 잘 안 맞네요ㅠㅠ 민수님이 혹시 시간 있으시면 봐주시면 감사하겠습니다.  이게 개발자 도구에서 responsive로 볼때랑 phone 갤럭시 S8+로 볼때랑 또 다르네요.
- 홈에서 길찾기 버튼은 아직 수정하지 않았는데 endName 리코일로 관리한 후 디자인 들어갈게요! 도착지 입력창 바로 밑에 같은 크기로 주황색 버튼으로 만드려고 합니다!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
[
<img width="179" alt="20240417_165130" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/62870362/b41d9b61-8733-4914-a93c-fbf0a071f95e">
](url)
