### PR TITLE
refactor: 도착지 장소 이름, 좌표 recoil 전역 상태 관리, 변경된 경유지 데이터 형식에 맞게 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { RecoilRoot } from 'recoil';
 import Home from './pages/Home';
 import EmergencyPage from './pages/EmergencyPage';
 import RouteExplorer from './pages/RouteExplorer';
+import DetailRoute from './pages/DetailRoute';
 
 const router = createBrowserRouter([
   {
@@ -13,6 +14,10 @@ const router = createBrowserRouter([
   {
     path: '/routes',
     element: <RouteExplorer />,
+  },
+  {
+    path: '/route-detail',
+    element: <DetailRoute />,
   },
   {
     path: '/emergency',

--- a/src/components/RouteCarousel/index.tsx
+++ b/src/components/RouteCarousel/index.tsx
@@ -6,12 +6,13 @@ import danger from '../../assets/images/danger.svg';
 interface RouteInfoProps {
   routeInfo: { time: string; distance: string };
   waypoints: Coord[];
+  onClick: React.MouseEventHandler<HTMLDivElement>;
 }
 
-function RouteCarousel({ routeInfo, waypoints }: RouteInfoProps) {
+function RouteCarousel({ routeInfo, waypoints, onClick }: RouteInfoProps) {
   const { time, distance } = routeInfo;
   return (
-    <Carousel>
+    <Carousel onClick={onClick}>
       <Info>
         <p className="time">{time}</p>
         <p className="distance">{distance}</p>

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import usePlaceSearch from '../../hooks/usePlaceSearch';
 import useCurrentPosition from '../../hooks/useCurruntPosition';
 import { updateAddressFromCurrentCoordinates } from '../../utils/mapUtils';
@@ -9,6 +10,7 @@ import {
   SearchResultContainer,
   SearchResultList,
 } from './style';
+import { endNameState, endPositionState } from '../../recoil/atoms';
 
 interface SearchBoxProps {
   searchState: SearchState;
@@ -23,11 +25,6 @@ interface SearchBoxProps {
 interface ContainerProps {
   // eslint-disable-next-line react/require-default-props
   setStartPosition?: React.Dispatch<React.SetStateAction<Coord>>;
-  setEndPosition: React.Dispatch<React.SetStateAction<Coord>>;
-  // eslint-disable-next-line react/require-default-props
-  endName?: string;
-  // eslint-disable-next-line react/require-default-props
-  setEndName?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 function SearchBox({
@@ -86,12 +83,9 @@ function SearchBox({
   );
 }
 
-function SearchContainer({
-  setStartPosition,
-  setEndPosition,
-  endName,
-  setEndName,
-}: ContainerProps) {
+function SearchContainer({ setStartPosition }: ContainerProps) {
+  const setEndPosition = useSetRecoilState(endPositionState);
+  const [endName, setEndName] = useRecoilState(endNameState);
   const { currentPosition } = useCurrentPosition();
   const [startSearchState, setStartSearchState] = useState<SearchState>({
     keyword: '',

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -1,16 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
 import Wrapper from '../components/common/Wrapper';
+import { endNameState } from '../recoil/atoms';
 
 function DetailRoute() {
+  const [endName, setEndName] = useRecoilState(endNameState);
+
   const { state } = useLocation();
-  console.log(state);
   const { currentPosition } = useCurrentPosition();
   const mapRef = useRef(null);
   const { map } = useMap(
@@ -109,7 +112,8 @@ function DetailRoute() {
       <SearchContainer
         setStartPosition={setStartPosition}
         setEndPosition={setEndPosition}
-        endName={state?.endName}
+        setEndName={setEndName}
+        endName={endName}
       />
 
       <div id="map_div" ref={mapRef} />

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -1,19 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
 import Wrapper from '../components/common/Wrapper';
-import { endNameState } from '../recoil/atoms';
+import { endPositionState } from '../recoil/atoms';
 
 function DetailRoute() {
-  const [endName, setEndName] = useRecoilState(endNameState);
-
-  const { state } = useLocation();
   const { currentPosition } = useCurrentPosition();
   const mapRef = useRef(null);
   const { map } = useMap(
@@ -25,10 +21,7 @@ function DetailRoute() {
     latitude: undefined,
     longitude: undefined,
   });
-  const [endPosition, setEndPosition] = useState<Coord>({
-    latitude: undefined,
-    longitude: undefined,
-  });
+  const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
   const [, setRouteInfo] = useState<{
@@ -73,12 +66,6 @@ function DetailRoute() {
   ]);
 
   useEffect(() => {
-    if (state && state.endPosition) {
-      setEndPosition(state.endPosition);
-    }
-  }, [state]);
-
-  useEffect(() => {
     if (!currentPosition) return;
 
     // 현재 위치 마커 생성 및 추가
@@ -109,12 +96,7 @@ function DetailRoute() {
 
   return (
     <Wrapper>
-      <SearchContainer
-        setStartPosition={setStartPosition}
-        setEndPosition={setEndPosition}
-        setEndName={setEndName}
-        endName={endName}
-      />
+      <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
 

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -1,17 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
-import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
 
-function RouteExplorer() {
-  const navigate = useNavigate();
+function DetailRoute() {
   const { state } = useLocation();
+  console.log(state);
   const { currentPosition } = useCurrentPosition();
   const mapRef = useRef(null);
   const { map } = useMap(
@@ -29,7 +28,7 @@ function RouteExplorer() {
   });
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
-  const [routeInfo, setRouteInfo] = useState<{
+  const [, setRouteInfo] = useState<{
     time: string;
     distance: string;
   }>();
@@ -105,12 +104,6 @@ function RouteExplorer() {
       .catch((error) => console.error('Error drawing route:', error));
   }, [map, startPosition, endPosition, waypoints]);
 
-  const onClick = () => {
-    navigate('/route-detail', {
-      state: { endPosition },
-    });
-  };
-
   return (
     <Wrapper>
       <SearchContainer
@@ -121,15 +114,9 @@ function RouteExplorer() {
 
       <div id="map_div" ref={mapRef} />
 
-      {routeInfo && (
-        <RouteCarousel
-          routeInfo={routeInfo}
-          waypoints={waypoints}
-          onClick={onClick}
-        />
-      )}
+      <button type="button">신고하기</button>
     </Wrapper>
   );
 }
 
-export default RouteExplorer;
+export default DetailRoute;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
 import BottomSheet from '../components/BottomSheet';
-import { Coord } from '../types/mapTypes';
 import useFilteringMarker from '../hooks/useFilteringMarker';
 import { WrapperContainer } from '../components/common/Wrapper/style';
-import { endNameState } from '../recoil/atoms';
 
 function Home() {
   const navigate = useNavigate();
@@ -27,16 +24,9 @@ function Home() {
     lat: 37.606,
     lng: 126.9576788,
   });
-  const [endPosition, setEndPosition] = useState<Coord>({
-    latitude: undefined,
-    longitude: undefined,
-  });
-  const [endName, setEndName] = useRecoilState<string>(endNameState);
 
   const findRoute = () => {
-    navigate('/routes', {
-      state: { endPosition },
-    });
+    navigate('/routes');
   };
 
   useEffect(() => {
@@ -51,11 +41,7 @@ function Home() {
 
   return (
     <WrapperContainer>
-      <SearchContainer
-        setEndPosition={setEndPosition}
-        endName={endName}
-        setEndName={setEndName}
-      />
+      <SearchContainer />
       <button type="button" onClick={findRoute}>
         길찾기
       </button>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker } from '../utils/mapUtils';
@@ -9,6 +10,7 @@ import BottomSheet from '../components/BottomSheet';
 import { Coord } from '../types/mapTypes';
 import useFilteringMarker from '../hooks/useFilteringMarker';
 import { WrapperContainer } from '../components/common/Wrapper/style';
+import { endNameState } from '../recoil/atoms';
 
 function Home() {
   const navigate = useNavigate();
@@ -29,11 +31,11 @@ function Home() {
     latitude: undefined,
     longitude: undefined,
   });
-  const [endName, setEndName] = useState<string>('');
+  const [endName, setEndName] = useRecoilState<string>(endNameState);
 
   const findRoute = () => {
     navigate('/routes', {
-      state: { endPosition, endName },
+      state: { endPosition },
     });
   };
 

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
@@ -8,6 +9,7 @@ import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
+import { endNameState } from '../recoil/atoms';
 
 function RouteExplorer() {
   const navigate = useNavigate();
@@ -33,6 +35,7 @@ function RouteExplorer() {
     time: string;
     distance: string;
   }>();
+  const [endName, setEndName] = useRecoilState(endNameState);
 
   const [waypoints] = useState([
     {
@@ -116,7 +119,8 @@ function RouteExplorer() {
       <SearchContainer
         setStartPosition={setStartPosition}
         setEndPosition={setEndPosition}
-        endName={state?.endName}
+        endName={endName}
+        setEndName={setEndName}
       />
 
       <div id="map_div" ref={mapRef} />

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -34,9 +34,39 @@ function RouteExplorer() {
   }>();
 
   const [waypoints] = useState([
-    { latitude: 37.48211807, longitude: 126.94151563 },
-    { latitude: 37.48334492, longitude: 126.94311689 },
-    { latitude: 37.48161125, longitude: 126.94127377 },
+    {
+      id: 16684.0,
+      longitude: 127.013,
+      latitude: 37.4932,
+      rank_score: 56.84,
+      emergency_bell_and_distance_score: 11.89,
+      safety_center_and_distacne_score: 19.85,
+      grid_shelter_distance_score: 77.78,
+      grid_facilities_distance_score: 55.56,
+      number_of_cctv_score: 5.48,
+    },
+    {
+      id: 17009.0,
+      longitude: 127.018,
+      latitude: 37.4554,
+      rank_score: 98.97,
+      emergency_bell_and_distance_score: 49.88,
+      safety_center_and_distacne_score: 52.04,
+      grid_shelter_distance_score: 100.0,
+      grid_facilities_distance_score: 100.0,
+      number_of_cctv_score: 24.94,
+    },
+    {
+      id: 17161.0,
+      longitude: 127.02,
+      latitude: 37.4554,
+      rank_score: 98.76,
+      emergency_bell_and_distance_score: 49.76,
+      safety_center_and_distacne_score: 50.22,
+      grid_shelter_distance_score: 100.0,
+      grid_facilities_distance_score: 100.0,
+      number_of_cctv_score: 100.0,
+    },
   ]);
 
   useEffect(() => {

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
@@ -9,11 +9,10 @@ import SearchContainer from '../components/Search';
 import { Coord } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
-import { endNameState } from '../recoil/atoms';
+import { endPositionState } from '../recoil/atoms';
 
 function RouteExplorer() {
   const navigate = useNavigate();
-  const { state } = useLocation();
   const { currentPosition } = useCurrentPosition();
   const mapRef = useRef(null);
   const { map } = useMap(
@@ -25,17 +24,13 @@ function RouteExplorer() {
     latitude: undefined,
     longitude: undefined,
   });
-  const [endPosition, setEndPosition] = useState<Coord>({
-    latitude: undefined,
-    longitude: undefined,
-  });
+  const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
   const [routeInfo, setRouteInfo] = useState<{
     time: string;
     distance: string;
   }>();
-  const [endName, setEndName] = useRecoilState(endNameState);
 
   const [waypoints] = useState([
     {
@@ -74,12 +69,6 @@ function RouteExplorer() {
   ]);
 
   useEffect(() => {
-    if (state && state.endPosition) {
-      setEndPosition(state.endPosition);
-    }
-  }, [state]);
-
-  useEffect(() => {
     if (!currentPosition) return;
 
     // 현재 위치 마커 생성 및 추가
@@ -109,19 +98,12 @@ function RouteExplorer() {
   }, [map, startPosition, endPosition, waypoints]);
 
   const onClick = () => {
-    navigate('/route-detail', {
-      state: { endPosition },
-    });
+    navigate('/route-detail');
   };
 
   return (
     <Wrapper>
-      <SearchContainer
-        setStartPosition={setStartPosition}
-        setEndPosition={setEndPosition}
-        endName={endName}
-        setEndName={setEndName}
-      />
+      <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
 

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,4 +1,5 @@
 import { atom } from 'recoil';
+import { Coord } from '../types/mapTypes';
 
 const filterState = atom<{ [key: string]: boolean }>({
   key: 'filterState',
@@ -17,4 +18,12 @@ export default filterState;
 export const endNameState = atom<string>({
   key: 'endNameState',
   default: '',
+});
+
+export const endPositionState = atom<Coord>({
+  key: 'endPositionState',
+  default: {
+    latitude: undefined,
+    longitude: undefined,
+  },
 });

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-const filterState = atom<{[key:string] : boolean}>({
+const filterState = atom<{ [key: string]: boolean }>({
   key: 'filterState',
   default: {
     cctv: false,
@@ -8,8 +8,13 @@ const filterState = atom<{[key:string] : boolean}>({
     safetyfacility: false,
     safetycenter: false,
     emergencybell: false,
-    heatshelter: false
-  }
+    heatshelter: false,
+  },
 });
 
 export default filterState;
+
+export const endNameState = atom<string>({
+  key: 'endNameState',
+  default: '',
+});


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
경유지 정보를 차트로 보여주기 위해서 위도, 경도 뿐만 아니라 6가지 위험 점수를 포함한 데이터로 수정했습니다. 
도착지의 장소 이름과 좌표가 메인, 길 찾기, 경로 상세 정보 3개의 페이지와 검색 컴포넌트에서 이용되는데 props로 넘겨주거나 navigate의 state으로 넘겨주다 보니 중복되는 코드가 많아지고 보수가 어려워져서 recoil로 관리하기로 했습니다!

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->
- [x] 경로 상세 정보 페이지 추가
- [x] 수정된 경유지 데이터로 변경
- [x] 도착지 장소 이름, 좌표 recoil로 전역 상태 관리

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #56 , #67 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
eslint no-console 규칙을 지키려고 throw new Error로 바꾸었더니 여기저기 에러가 던져져서 에러 처리를 좀 더 한 후에 배포 하거나 eslint no-console 규칙을 꺼 버리고 임시 배포 해보는 것이 좋을 것 같아요!!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
