### PR TITLE
design : bottom sheet 위치 fix

### DIFF
--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -20,17 +20,15 @@ export const Wrapper = styled(motion.div)`
 
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.6);
   height: ${BOTTOM_SHEET_HEIGHT}px;
 
   /* background: linear-gradient(359.26deg, #3C41C7 0.02%, #3742B2 83.23%, #3642AE 98.76%); */
   background: #fff;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 4px rgba(0, 0, 0, 0.25);
 
   transition: transform 650ms ease-out; /*바텀시트 애니메이션 속도*/
 `;
 
 export const BottomSheetContent = styled.div`
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
+overflow: none;
 `;

--- a/src/components/BottomSheetContents/style.ts
+++ b/src/components/BottomSheetContents/style.ts
@@ -17,16 +17,25 @@ export const Label = styled.label`
 `;
 
 export const ButtonWrapper = styled.div`
+  width: 100%;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
   gap: 0.5rem;
   padding: 1rem;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
 `;
 
 export const FacilityButton = styled.button<FacilityButtonProps>`
+  min-width: 4.5rem;
   width: fit-content;
   height: 2rem;
-  padding: 6px 12px;
+  padding: 6px 6px;
   border: none;
   border-radius: 2rem;
   background-color: ${(props) => (props.$isClicked ? '#F9ECD4' : '#F4F4F4')};

--- a/src/components/common/Wrapper/style.ts
+++ b/src/components/common/Wrapper/style.ts
@@ -5,7 +5,7 @@ export const WrapperContainer = styled.div`
   /* 공통 스타일링 */
   max-width: 360px;
   /* background-color: yellow; */
-  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/constant/bottomSheetPosition.ts
+++ b/src/constant/bottomSheetPosition.ts
@@ -1,8 +1,8 @@
 // 바텀 시트가 최대로 올라갔을 때 Y값
-export const MIN_Y = 80;
-// 바텀 시트가 최소로 내려갔을 때 Y값
-export const MAX_Y = window.innerHeight - 200;
+export const MIN_Y = 250;
 // 바텀 시트가 아래에 있을 때 높이
-export const BOTTOM_SHEET_DEFAULT_HEIGHT = 222;
+export const BOTTOM_SHEET_DEFAULT_HEIGHT = 180;
+// 바텀 시트가 최소로 내려갔을 때 Y값
+export const MAX_Y = window.innerHeight - BOTTOM_SHEET_DEFAULT_HEIGHT;
 // 바텀 시트의 높이
 export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y;


### PR DESCRIPTION
### 개요

BottomSheet 위치가 너무 많이 올라가는 버그 수정했습니다.

### 작업 내용

- [x] BottomSheet의 위치 및 크기를 재조정했습니다.
- [x] BottomSheet의 그림자를 수정했습니다 (우측 그림자 삭제)
- [x] /common/Wrapper의 height 값을 100vh -> 100dvh로 수정했습니다 (모바일을 신경쓴다면 이게 더 좋을 것 같습니다!!)
  - 추가적으로 만약 vw를 쓰게 된다면 dvw 로 쓰는게 더 좋을 것 같습니다!!
- [x] BottomSheet의 필터링 버튼 Container의 디자인을 수정했습니다.
  - 추후 mouseMove 이벤트로도 양 옆으로 움직일 수 있도록 수정 예정

### 관련 이슈

Closes #64

### 질문

### 스크린샷 (선택 사항)

<img width="355" alt="스크린샷 2024-04-18 오후 2 30 42" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/104495388/66c272a7-26ab-4268-a4bd-9e224f013fd1">
<img width="367" alt="스크린샷 2024-04-18 오후 2 30 34" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/104495388/657ba29b-8074-4b8a-abe8-b87e07737517">

