### PR TITLE
design : emergencyPage 헤더 디자인 및 기능 구현

### DIFF
--- a/src/components/EmergencyHeader/index.tsx
+++ b/src/components/EmergencyHeader/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BackBtn, Wrapper } from './style';
+
+function EmergencyHeader({title} : {title: string}) {
+  const navigate = useNavigate();
+
+  const handleClick= () => {
+    navigate(-1);
+  };
+
+  return (
+    <Wrapper>
+      <BackBtn onMouseDown={handleClick}>&lt;</BackBtn>
+      <p>{title} 신고</p>
+    </Wrapper>
+  );
+}
+
+export default EmergencyHeader;

--- a/src/components/EmergencyHeader/style.ts
+++ b/src/components/EmergencyHeader/style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+`;
+
+export const BackBtn = styled.p`
+    cursor: pointer;
+    font-size: 18px;
+    font-weight: 600;
+    padding: 1.2rem 0.7rem;
+`;

--- a/src/components/ReportList/index.tsx
+++ b/src/components/ReportList/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ContentsWrapper, Wrapper } from './style';
 import timeStamp from '../../constant/mockingTimeStamp';
 
-export function convertDateFormat(isoDateString:string) {
+export function convertDateFormat(isoDateString:string):string {
   const date = new Date(isoDateString);
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');

--- a/src/hooks/useFilteringMarker.ts
+++ b/src/hooks/useFilteringMarker.ts
@@ -70,7 +70,7 @@ function useFilteringMarker({ map, lat, lng }: UseFilteringMarkerProps): void {
       .catch(err => {
         console.error(err);
       });
-  }, [filterValue, lat, lng]);
+  }, [filterValue, lat, lng, map]);
 }
 
 export default useFilteringMarker;

--- a/src/pages/EmergencyPage.tsx
+++ b/src/pages/EmergencyPage.tsx
@@ -5,6 +5,9 @@ import useCurrentPosition from '../hooks/useCurruntPosition';
 import useEmergencyMarker from '../hooks/useEmergencyMarker';
 import { WrapperContainer } from '../components/common/Wrapper/style';
 import useFilteringMarker from '../hooks/useFilteringMarker';
+import EmergencyHeader from '../components/EmergencyHeader';
+import timeStamp from '../constant/mockingTimeStamp';
+import { convertDateFormat } from '../components/ReportList';
 
 function EmergencyPage() {
   const mapRef = useRef(null);
@@ -22,8 +25,11 @@ function EmergencyPage() {
     lng: 127.073,
   });
 
+  const STAMP = timeStamp.filter(item => item.id === Number(emergencyId))[0];
+
   return (
     <WrapperContainer>
+      <EmergencyHeader title={convertDateFormat(STAMP.timestamp)} />
       <div id="map_div" ref={mapRef} />
     </WrapperContainer>
   );


### PR DESCRIPTION
### 개요

emergencyPage의 헤더를 디자인하고 기능을 구현했습니다.

### 작업 내용

- [x] emergencyHeader 컴포넌트 생성 및 디자인
- [x] 페이지 전환 시 안전시설 마커가 표시되지 않는 버그 해결

### 관련 이슈

Closes #77 

### 질문

뒤로가기를 "<" 이걸로 일단 해놨는데, 화살표 이미지로 하는게 좋을까요?? 한번 보고 말씀해주세요!!

아 그리고 신고하기 버튼 기능과 디자인을 제가 한번 해볼까요?!!
API도 나왔다고 해서 바로 만들고, 헤더랑 연결하면 될 것 같아서요!!

### 스크린샷 (선택 사항)

<img width="349" alt="스크린샷 2024-04-19 오전 11 31 31" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/104495388/7af739ee-ede9-4d51-b014-bb35c635457f">

