### PR TITLE
feat: 경유지 위험 지표 점수 레이더 차트로 시각화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "recharts": "^2.12.5",
         "recoil": "^0.7.7",
         "styled-components": "^6.1.8",
         "typescript": "^4.9.5",
@@ -4160,6 +4161,60 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.7",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
@@ -6298,6 +6353,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6981,6 +7044,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7067,6 +7240,11 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -7305,6 +7483,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -8686,6 +8873,14 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -9951,6 +10146,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -15609,6 +15812,35 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+      "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15640,6 +15872,41 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.5.tgz",
+      "integrity": "sha512-Cy+BkqrFIYTHJCyKHJEPvbHE2kVQEP6PKbOHJ8ztRGTAhvHuUnCwDaKVb13OwRFZ0QNUk1QvGTDdgWSMbuMtKw==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^16.10.2",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/recoil": {
       "version": "0.7.7",
@@ -17469,6 +17736,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -17947,6 +18219,27 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "recharts": "^2.12.5",
     "recoil": "^0.7.7",
     "styled-components": "^6.1.8",
     "typescript": "^4.9.5",

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+} from 'recharts';
+import { transformData } from '../../utils/mapUtils';
+import { WaypointInfo } from '../../types/mapTypes';
+
+interface ChartProps {
+  data: WaypointInfo;
+}
+
+function Chart({ data }: ChartProps) {
+  const riskData = transformData(data);
+  return (
+    <RadarChart width={200} height={200} data={riskData}>
+      <PolarGrid />
+      <PolarAngleAxis dataKey="subject" />
+      <PolarRadiusAxis />
+      <Radar
+        name="Scores"
+        dataKey="A"
+        stroke="#8884d8"
+        fill="#8884d8"
+        fillOpacity={0.6}
+      />
+    </RadarChart>
+  );
+}
+
+export default Chart;

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -11,7 +11,7 @@ import { transformData } from '../../utils/mapUtils';
 import { WaypointInfo } from '../../types/mapTypes';
 
 interface ChartProps {
-  data: WaypointInfo;
+  data: WaypointInfo | undefined;
 }
 
 function Chart({ data }: ChartProps) {

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'recharts';
 import { transformData } from '../../utils/mapUtils';
 import { WaypointInfo } from '../../types/mapTypes';
+import { ChartWrapper, Content } from './style';
 
 interface ChartProps {
   data: WaypointInfo | undefined;
@@ -16,19 +17,27 @@ interface ChartProps {
 
 function Chart({ data }: ChartProps) {
   const riskData = transformData(data);
+
   return (
-    <RadarChart width={200} height={200} data={riskData}>
-      <PolarGrid />
-      <PolarAngleAxis dataKey="subject" />
-      <PolarRadiusAxis />
-      <Radar
-        name="Scores"
-        dataKey="A"
-        stroke="#8884d8"
-        fill="#8884d8"
-        fillOpacity={0.6}
-      />
-    </RadarChart>
+    <ChartWrapper>
+      <RadarChart width={170} height={130} data={riskData}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="risk" tick={{ fontSize: 8 }} />
+        <PolarRadiusAxis tick={{ fontSize: 5 }} />
+        <Radar
+          name="risk-scores"
+          dataKey="A"
+          stroke="#FF5757"
+          fill="#FF5757"
+          fillOpacity={0.6}
+        />
+      </RadarChart>
+      <Content>
+        <p>cctv가 별로 없어요</p>
+        <p>안전시설이 멀어요</p>
+        <p>더위 쉼터가 없어요</p>
+      </Content>
+    </ChartWrapper>
   );
 }
 

--- a/src/components/Chart/style.ts
+++ b/src/components/Chart/style.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const ChartWrapper = styled.div`
+  width: 20rem;
+  height: 8rem;
+  border-radius: 0.4rem;
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.5rem;
+  box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
+  background-color: #ffffff;
+  position: fixed;
+  bottom: 3rem;
+  left: 1.25rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+
+  p {
+    font-size: 0.7rem;
+  }
+`;

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -68,7 +68,7 @@ function DetailRoute() {
   const [selectedMarkerId, setSelectedMarkerId] = useState<
     number | undefined
   >();
-  console.log(selectedMarkerId);
+
   useEffect(() => {
     if (!currentPosition) return;
 

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -65,7 +65,10 @@ function DetailRoute() {
       number_of_cctv_score: 100.0,
     },
   ]);
-
+  const [selectedMarkerId, setSelectedMarkerId] = useState<
+    number | undefined
+  >();
+  console.log(selectedMarkerId);
   useEffect(() => {
     if (!currentPosition) return;
 
@@ -80,7 +83,15 @@ function DetailRoute() {
   useEffect(() => {
     if (!map) return;
 
-    drawRoute(map, startPosition, endPosition, waypoints, polylines, markers)
+    drawRoute(
+      map,
+      startPosition,
+      endPosition,
+      waypoints,
+      polylines,
+      markers,
+      setSelectedMarkerId,
+    )
       .then(({ newPolylines, newMarkers, tTime, tDistance }) => {
         setPolylines(newPolylines);
         setMarkers(newMarkers);
@@ -100,7 +111,12 @@ function DetailRoute() {
       <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
-      <Chart data={waypoints[1]} />
+
+      {selectedMarkerId !== undefined && (
+        <Chart
+          data={waypoints.find((waypoint) => waypoint.id === selectedMarkerId)}
+        />
+      )}
 
       <button type="button">신고하기</button>
     </Wrapper>

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -5,9 +5,10 @@ import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
-import { Coord } from '../types/mapTypes';
+import { Coord, WaypointInfo } from '../types/mapTypes';
 import Wrapper from '../components/common/Wrapper';
 import { endPositionState } from '../recoil/atoms';
+import Chart from '../components/Chart';
 
 function DetailRoute() {
   const { currentPosition } = useCurrentPosition();
@@ -29,7 +30,7 @@ function DetailRoute() {
     distance: string;
   }>();
 
-  const [waypoints] = useState([
+  const [waypoints] = useState<WaypointInfo[]>([
     {
       id: 16684.0,
       longitude: 127.013,
@@ -99,6 +100,7 @@ function DetailRoute() {
       <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
+      <Chart data={waypoints[1]} />
 
       <button type="button">신고하기</button>
     </Wrapper>

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -6,7 +6,7 @@ import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
-import { Coord } from '../types/mapTypes';
+import { Coord, WaypointInfo } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
 import { endPositionState } from '../recoil/atoms';
@@ -32,7 +32,7 @@ function RouteExplorer() {
     distance: string;
   }>();
 
-  const [waypoints] = useState([
+  const [waypoints] = useState<WaypointInfo[]>([
     {
       id: 16684.0,
       longitude: 127.013,

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -33,3 +33,15 @@ export interface Place {
   latitude: number;
   longitude: number;
 }
+
+export interface WaypointInfo {
+  id: number;
+  longitude: number;
+  latitude: number;
+  rank_score: number;
+  emergency_bell_and_distance_score: number;
+  safety_center_and_distacne_score: number;
+  grid_shelter_distance_score: number;
+  grid_facilities_distance_score: number;
+  number_of_cctv_score: number;
+}

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -294,6 +294,9 @@ export const drawRoute = async (
         marker.addListener('click', () => {
           setSelectedMarkerId(waypoint.id);
         });
+        marker.addListener('touchstart', () => {
+          setSelectedMarkerId(waypoint.id);
+        });
       }
       markers.push(marker);
     });
@@ -352,10 +355,10 @@ export const drawRoute = async (
 export const transformData = (data: WaypointInfo | undefined) => {
   if (!data) return [];
   return [
-    { subject: 'Emergency Bell', A: data.emergency_bell_and_distance_score },
-    { subject: 'Safety Center', A: data.safety_center_and_distacne_score },
-    { subject: 'Grid Shelter', A: data.grid_shelter_distance_score },
-    { subject: 'Grid Facilities', A: data.grid_facilities_distance_score },
-    { subject: 'Number of CCTV', A: data.number_of_cctv_score },
+    { risk: '응급상황벨', A: data.emergency_bell_and_distance_score },
+    { risk: '안전센터', A: data.safety_center_and_distacne_score },
+    { risk: '보호시설', A: data.grid_shelter_distance_score },
+    { risk: '안전시설', A: data.grid_facilities_distance_score },
+    { risk: 'CCTV', A: data.number_of_cctv_score },
   ];
 };

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -18,6 +18,7 @@ import {
   Tmapv2,
   Coord,
   Place,
+  WaypointInfo,
 } from '../types/mapTypes';
 
 const getImageSrc = (facilities?: FacilitiesType) => {
@@ -229,9 +230,12 @@ export const drawRoute = async (
   map: any,
   startPosition: Coord,
   endPosition: Coord,
-  waypoints: Coord[],
+  waypoints: WaypointInfo[],
   prevPolylines: any[],
   prevMarkers: any[],
+  setSelectedMarkerId?: React.Dispatch<
+    React.SetStateAction<number | undefined>
+  >,
 ) => {
   try {
     // 이전 경로, 마커 제거
@@ -286,6 +290,11 @@ export const drawRoute = async (
         iconSize: new Tmapv2.Size(26, 34),
         map,
       });
+      if (setSelectedMarkerId) {
+        marker.addListener('click', () => {
+          setSelectedMarkerId(waypoint.id);
+        });
+      }
       markers.push(marker);
     });
 
@@ -340,7 +349,8 @@ export const drawRoute = async (
   }
 };
 
-export const transformData = (data: any) => {
+export const transformData = (data: WaypointInfo | undefined) => {
+  if (!data) return [];
   return [
     { subject: 'Emergency Bell', A: data.emergency_bell_and_distance_score },
     { subject: 'Safety Center', A: data.safety_center_and_distacne_score },

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -339,3 +339,13 @@ export const drawRoute = async (
     return { newPolylines: [], newMarkers: [], tTime: '', tDistance: '' };
   }
 };
+
+export const transformData = (data: any) => {
+  return [
+    { subject: 'Emergency Bell', A: data.emergency_bell_and_distance_score },
+    { subject: 'Safety Center', A: data.safety_center_and_distacne_score },
+    { subject: 'Grid Shelter', A: data.grid_shelter_distance_score },
+    { subject: 'Grid Facilities', A: data.grid_facilities_distance_score },
+    { subject: 'Number of CCTV', A: data.number_of_cctv_score },
+  ];
+};


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
경유지의 5가지 위험 점수를 한눈에 볼 수 있도록 위해 레이더 차트를 사용했습니다. 

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 리액트에서 사용하기 쉬운 차트 라이브러리인 recharts를 추가했어요
- [x] 경유지 마커에 click, touchstart 이벤트를 추가해 선택된 경유지의 위험 점수를 레이더 차트로 보여주게 만들었어요

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #70 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- recharts 라이브러리 추가되었으니 pull 당기고 설치해주세요 
- 평균 점수는 아직 보여주지 않아서 처음 경로 상세 정보 페이지 들어가면 차트가 없다가 경유지 클릭해야 나옵니다!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
<img width="179" alt="20240419_133001" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/62870362/3c65ab24-15f7-4729-ac29-a26dac88cda7">

