### PR TITLE
feat: 경로 내 위험 경유지 받아오는 api 연결

### DIFF
--- a/src/api/routeAPI.ts
+++ b/src/api/routeAPI.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { Coord } from '../types/mapTypes';
+
+const getWaypoints = async (start: Coord, end: Coord) => {
+  try {
+    const response = await axios.get(
+      `https://jcigc40pak.execute-api.ap-northeast-2.amazonaws.com/seoul-public/route?start_lon=${start.longitude}&start_lat=${start.latitude}&arrival_lon=${end.longitude}&arrival_lat=${end.latitude}`,
+    );
+    return response.data.body;
+  } catch (error) {
+    console.error('Error fetching waypoints:', error);
+    return [];
+  }
+};
+
+export default getWaypoints;

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -8,15 +8,16 @@ import {
   PolarRadiusAxis,
 } from 'recharts';
 import { transformData } from '../../utils/mapUtils';
-import { WaypointInfo } from '../../types/mapTypes';
+import { WaypointInfo, WaypointMean } from '../../types/mapTypes';
 import { ChartWrapper, Content } from './style';
 
 interface ChartProps {
-  data: WaypointInfo | undefined;
+  data: WaypointInfo | WaypointMean | undefined;
+  type: 'info' | 'mean';
 }
 
-function Chart({ data }: ChartProps) {
-  const riskData = transformData(data);
+function Chart({ data, type }: ChartProps) {
+  const riskData = transformData(data, type);
 
   return (
     <ChartWrapper>

--- a/src/components/Chart/style.ts
+++ b/src/components/Chart/style.ts
@@ -9,7 +9,7 @@ export const ChartWrapper = styled.div`
   padding: 0.5rem;
   box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
   background-color: #ffffff;
-  position: relative;
+  position: absolute;
   bottom: 6rem;
 `;
 

--- a/src/components/Chart/style.ts
+++ b/src/components/Chart/style.ts
@@ -9,9 +9,8 @@ export const ChartWrapper = styled.div`
   padding: 0.5rem;
   box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
   background-color: #ffffff;
-  position: fixed;
+  position: relative;
   bottom: 6rem;
-  left: 1.25rem;
 `;
 
 export const Content = styled.div`

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -2,11 +2,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import axios from 'axios';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
-import { Coord, WaypointInfo } from '../types/mapTypes';
+import { Coord, WaypointInfo, WaypointMean } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
 import { endPositionState } from '../recoil/atoms';
@@ -32,41 +33,33 @@ function RouteExplorer() {
     distance: string;
   }>();
 
-  const [waypoints] = useState<WaypointInfo[]>([
-    {
-      id: 16684.0,
-      longitude: 127.013,
-      latitude: 37.4932,
-      rank_score: 56.84,
-      emergency_bell_and_distance_score: 11.89,
-      safety_center_and_distacne_score: 19.85,
-      grid_shelter_distance_score: 77.78,
-      grid_facilities_distance_score: 55.56,
-      number_of_cctv_score: 5.48,
-    },
-    {
-      id: 17009.0,
-      longitude: 127.018,
-      latitude: 37.4554,
-      rank_score: 98.97,
-      emergency_bell_and_distance_score: 49.88,
-      safety_center_and_distacne_score: 52.04,
-      grid_shelter_distance_score: 100.0,
-      grid_facilities_distance_score: 100.0,
-      number_of_cctv_score: 24.94,
-    },
-    {
-      id: 17161.0,
-      longitude: 127.02,
-      latitude: 37.4554,
-      rank_score: 98.76,
-      emergency_bell_and_distance_score: 49.76,
-      safety_center_and_distacne_score: 50.22,
-      grid_shelter_distance_score: 100.0,
-      grid_facilities_distance_score: 100.0,
-      number_of_cctv_score: 100.0,
-    },
-  ]);
+  const [waypoints, setWaypoints] = useState<WaypointInfo[]>([]);
+  const [mean, setMean] = useState<WaypointMean | null>(null);
+
+  const fetchWaypoints = async () => {
+    try {
+      const response = await axios.get(
+        `https://jcigc40pak.execute-api.ap-northeast-2.amazonaws.com/seoul-public/route?start_lon=${startPosition.longitude}&start_lat=${startPosition.latitude}&arrival_lon=${endPosition.longitude}&arrival_lat=${endPosition.latitude}`,
+      );
+      const data = response.data.body;
+      const extractedWaypoints = data.slice(0, 5);
+      setWaypoints(extractedWaypoints);
+      setMean(data[data.length - 1][0]);
+    } catch (error) {
+      console.error('Error fetching waypoints:', error);
+    }
+  };
+
+  useEffect(() => {
+    if (
+      !startPosition.latitude ||
+      !startPosition.longitude ||
+      !endPosition.latitude ||
+      !endPosition.longitude
+    )
+      return;
+    fetchWaypoints();
+  }, [endPosition, startPosition]);
 
   useEffect(() => {
     if (!currentPosition) return;
@@ -80,8 +73,7 @@ function RouteExplorer() {
   }, [map]);
 
   useEffect(() => {
-    if (!map) return;
-
+    if (waypoints.length === 0) return;
     drawRoute(map, startPosition, endPosition, waypoints, polylines, markers)
       .then(({ newPolylines, newMarkers, tTime, tDistance }) => {
         setPolylines(newPolylines);
@@ -98,7 +90,7 @@ function RouteExplorer() {
   }, [map, startPosition, endPosition, waypoints]);
 
   const onClick = () => {
-    navigate('/route-detail');
+    navigate('/route-detail', { state: mean });
   };
 
   return (

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -45,3 +45,12 @@ export interface WaypointInfo {
   grid_facilities_distance_score: number;
   number_of_cctv_score: number;
 }
+
+export interface WaypointMean {
+  rank_score_mean: number;
+  emergency_bell_and_distance_score_mean: number;
+  safety_center_and_distacne_score_mean: number;
+  grid_shelter_distance_score_mean: number;
+  grid_facilities_distance_score_mean: number;
+  number_of_cctv_score_mean: number;
+}

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,6 +1,16 @@
+/* eslint-disable indent */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import axios from 'axios';
+import {
+  WaypointMean,
+  FacilitiesType,
+  SearchState,
+  Tmapv2,
+  Coord,
+  Place,
+  WaypointInfo,
+} from '../types/mapTypes';
 import cctv from '../assets/images/cctv.png';
 import emergencyBell from '../assets/images/emergencybell.png';
 import safetFacility from '../assets/images/safetyfacility.png';
@@ -15,15 +25,6 @@ import pp2 from '../assets/images/pp2.png';
 import pp3 from '../assets/images/pp3.png';
 import pp4 from '../assets/images/pp4.png';
 import pp5 from '../assets/images/pp5.png';
-
-import {
-  FacilitiesType,
-  SearchState,
-  Tmapv2,
-  Coord,
-  Place,
-  WaypointInfo,
-} from '../types/mapTypes';
 
 const getImageSrc = (facilities?: FacilitiesType) => {
   switch (facilities) {
@@ -374,13 +375,52 @@ export const drawRoute = async (
   }
 };
 
-export const transformData = (data: WaypointInfo | undefined) => {
+function isWaypointInfo(data: any): data is WaypointInfo {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'emergency_bell_and_distance_score' in data &&
+    'safety_center_and_distacne_score' in data &&
+    'grid_shelter_distance_score' in data &&
+    'grid_facilities_distance_score' in data &&
+    'number_of_cctv_score' in data
+  );
+}
+
+function isWaypointMean(data: any): data is WaypointMean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'emergency_bell_and_distance_score_mean' in data &&
+    'safety_center_and_distacne_score_mean' in data &&
+    'grid_shelter_distance_score_mean' in data &&
+    'grid_facilities_distance_score_mean' in data &&
+    'number_of_cctv_score_mean' in data
+  );
+}
+
+export const transformData = (
+  data: WaypointInfo | WaypointMean | undefined,
+  type: 'info' | 'mean',
+) => {
   if (!data) return [];
-  return [
-    { risk: '응급상황벨', A: data.emergency_bell_and_distance_score },
-    { risk: '안전센터', A: data.safety_center_and_distacne_score },
-    { risk: '보호시설', A: data.grid_shelter_distance_score },
-    { risk: '안전시설', A: data.grid_facilities_distance_score },
-    { risk: 'CCTV', A: data.number_of_cctv_score },
-  ];
+  if (type === 'info' && isWaypointInfo(data)) {
+    return [
+      { risk: '응급상황벨', A: data.emergency_bell_and_distance_score },
+      { risk: '안전센터', A: data.safety_center_and_distacne_score },
+      { risk: '보호시설', A: data.grid_shelter_distance_score },
+      { risk: '안전시설', A: data.grid_facilities_distance_score },
+      { risk: 'CCTV', A: data.number_of_cctv_score },
+    ];
+  }
+  if (type === 'mean' && isWaypointMean(data)) {
+    return [
+      { risk: '응급상황벨', A: data.emergency_bell_and_distance_score_mean },
+      { risk: '안전센터', A: data.safety_center_and_distacne_score_mean },
+      { risk: '보호시설', A: data.grid_shelter_distance_score_mean },
+      { risk: '안전시설', A: data.grid_facilities_distance_score_mean },
+      { risk: 'CCTV', A: data.number_of_cctv_score_mean },
+    ];
+  }
+  return [];
 };


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
임의의 waypoints 데이터를 api를 통해 받아오도록 수정했습니다. 

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->
- [x] 경로 찾기 api 연결
- [x] tanstack query로 경유지 데이터 받아오도록 수정했어요. 쿼리 키로 출발, 도착 좌표를 추가해서 같은 경로인 경우 캐시된 데이터를 받아오도록 했습니다! 

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #86 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
-  api 요청 후 응답까지 15-20초 정도 걸리는데 엄청 길게 느껴집니다. 로딩 상태를 UI를 추가해야할 것 같아요!
- 응답에 7개의 경유지가 오는데 회의 때 최대 5개까지만 달라고 이야기 드리고, 추천 경로의 거리?가 너무 멀어서 거리에 우선순위를 더 많이 달라고 이야기 할 생각입니다. 
- 아직 api 연결할 때 리액트 쿼리를 사용하지 않았습니다! 현재 응답 시간이 꽤 긴데 길 찾기 페이지와 경로 상세 페이지 모두에서 같은 경로로 요청을 보내서 더 오래 걸린다고 느껴집니다. 리액트 쿼리 도입해서 출발,도착지 동일하면 캐시된 데이터 사용하도록 해서 시간을 줄일 생각입니다.
- [임시 배포 url]( https://lets-go-petrol.netlify.app/) netlify로 임시 배포했는데 netlify는 https고 서버는 http라 mixed content 에러가 납니다! 

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
