### PR TITLE
feat: 도착지 선택시 지도중심 옮기고 마커 표시

### DIFF
--- a/src/components/RouteCarousel/style.ts
+++ b/src/components/RouteCarousel/style.ts
@@ -14,6 +14,10 @@ export const Carousel = styled.div`
   position: fixed;
   bottom: 1.2rem;
   left: 1.25rem;
+
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export const Info = styled.div`

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -39,6 +39,7 @@ function DetailRoute() {
   const { data } = useQuery({
     queryKey: ['waypoints', startPosition, endPosition],
     queryFn: () => getWaypoints(startPosition, endPosition),
+    staleTime: 60000,
   });
 
   const waypoints = useMemo(() => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ function Home() {
 
   return (
     <Wrapper>
-      <SearchContainer />
+      <SearchContainer map={map} />
       <div id="map_div" ref={mapRef} />
       <BottomSheet />
     </Wrapper>

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -37,6 +37,7 @@ function RouteExplorer() {
   const { data } = useQuery({
     queryKey: ['waypoints', startPosition, endPosition],
     queryFn: () => getWaypoints(startPosition, endPosition),
+    staleTime: 60000,
   });
 
   const waypoints = useMemo(() => {


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
홈에서 도착지를 선택했을 때 지도 중심을 도착지 좌표로 옮기고 줌 당기고 마커를 표시하도록 수정했어요!

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->
- [x] 도착지 선택 마커 표시
- [x] 경로 상세 페이지를 살펴보다가 뒤로 가기를 누르는 경우를 위해 경유지 데이터 staleTime을 1분으로 설정했습니다.

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #83 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
