### PR TITLE
design: 경로 찾기 api 응답 기다리는 동안 스켈레톤 UI 표시

### DIFF
--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { SkeletonWrapper, SkeletonText } from './style';
+
+function Skeleton() {
+  return (
+    <SkeletonWrapper>
+      <SkeletonText />
+      <SkeletonText />
+    </SkeletonWrapper>
+  );
+}
+
+export default Skeleton;

--- a/src/components/Skeleton/style.ts
+++ b/src/components/Skeleton/style.ts
@@ -1,0 +1,33 @@
+import styled, { keyframes } from 'styled-components';
+
+const loadingAnimation = keyframes`
+  0% {
+    background-position: -4rem 0;
+  }
+  100% {
+    background-position: calc(4rem + 100%) 0;
+  }
+`;
+
+export const SkeletonWrapper = styled.div`
+  width: 80%;
+  height: 7rem;
+  border-radius: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  justify-content: center;
+  padding-inline: 1rem;
+  background-color: #ffffff;
+  box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  bottom: 1.2rem;
+`;
+
+export const SkeletonText = styled.div`
+  width: 6rem;
+  height: 1.5rem;
+  border-radius: 0.8rem;
+  background: linear-gradient(90deg, #f1f0f0 0%, #e1e1e1 50%, #f1f0f0 100%);
+  animation: ${loadingAnimation} 1.5s infinite;
+`;

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -12,6 +12,7 @@ import { Coord } from '../types/mapTypes';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
 import { endPositionState } from '../recoil/atoms';
+import Skeleton from '../components/Skeleton';
 
 function RouteExplorer() {
   const navigate = useNavigate();
@@ -34,7 +35,7 @@ function RouteExplorer() {
     distance: string;
   }>();
 
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['waypoints', startPosition, endPosition],
     queryFn: () => getWaypoints(startPosition, endPosition),
     staleTime: 60000,
@@ -84,13 +85,16 @@ function RouteExplorer() {
       <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
-
-      {routeInfo && (
-        <RouteCarousel
-          routeInfo={routeInfo}
-          waypoints={waypoints}
-          onClick={onClick}
-        />
+      {isLoading ? (
+        <Skeleton />
+      ) : (
+        routeInfo && (
+          <RouteCarousel
+            routeInfo={routeInfo}
+            waypoints={waypoints}
+            onClick={onClick}
+          />
+        )
       )}
     </Wrapper>
   );


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
경로 찾기 api의 응답 시간 동안 좀 더 빠르게 로드되는 것처럼 보이도록 skeleton UI를 구현했습니다. 일반적인 로딩바를 넣으려고 했지만 지도 위에서 위치가 애매하고 로딩 시간이 꽤 길어서 다음 콘텐츠를 예측할 수 있는 UI가 보다 나은 사용자 경험을 제공할 것 같다고 생각했습니다!

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 스켈레톤 UI 구현

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #101 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
<img width="170" alt="skeleton" src="https://github.com/Seoul-Public-Data/seoul_frontend/assets/62870362/fc6c808b-03f9-401c-9e78-6f9e4cd75cb0">

