### PR TITLE
refactor: 장소 검색 시 debounce로 불필요한 api 요청 줄임

### DIFF
--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -5,14 +5,25 @@ import { Place } from '../types/mapTypes';
 
 const usePlaceSearch = (keyword: string): Place[] => {
   const [places, setPlaces] = useState<Place[]>([]);
+  const [debouncedKeyword, setDebouncedKeyword] = useState<string>('');
 
   useEffect(() => {
-    if (keyword) {
-      searchPOI(keyword, setPlaces);
+    const debounceTimer = setTimeout(() => {
+      setDebouncedKeyword(keyword);
+    }, 300);
+
+    return () => {
+      clearTimeout(debounceTimer);
+    };
+  }, [keyword]);
+
+  useEffect(() => {
+    if (debouncedKeyword) {
+      searchPOI(debouncedKeyword, setPlaces);
     }
 
     return () => {};
-  }, [keyword]);
+  }, [debouncedKeyword]);
 
   return places;
 };


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
keyword가 변경될 때마다 티맵에 장소 검색 api를 불필요하게 많이 요청하는 문제를 해결하기 위해 debounce를 적용했습니다.  

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 사용자가 연속적으로 입력을 하다 300ms 이상 멈추면 검색 요청을 보내도록 수정했습니다.

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #100 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- throttle로 검색 요청을 줄이는 것도 고민해봤는데 throttle은 사용자가 입력하는 동안 일정한 간격으로 검색 요청을 보내는 방식이더라구요. 저는 사용자가 빠르게 입력하다 잠깐 멈췄을 때 검색 요청을 보내는 debounce가 더 적합하다고 생각했는데 민수님 생각은 어떠신지 궁금합니다! 

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
