### PR TITLE
feat: 출도착지 현위치로 선택 기능 추가 및 경유지가 없는 경우 예외처리

### DIFF
--- a/src/api/routeAPI.ts
+++ b/src/api/routeAPI.ts
@@ -2,10 +2,16 @@ import axios from 'axios';
 import { Coord } from '../types/mapTypes';
 
 const getWaypoints = async (start: Coord, end: Coord) => {
+  if (!start || !end) {
+    return [];
+  }
   try {
     const response = await axios.get(
       `https://jcigc40pak.execute-api.ap-northeast-2.amazonaws.com/seoul-public/route?start_lon=${start.longitude}&start_lat=${start.latitude}&arrival_lon=${end.longitude}&arrival_lat=${end.latitude}`,
     );
+    if (response.data.errorMessage) {
+      return [];
+    }
     return response.data.body;
   } catch (error) {
     console.error('Error fetching waypoints:', error);

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -34,18 +34,23 @@ function Chart({ data, type }: ChartProps) {
         />
       </RadarChart>
       <Content>
-        {riskData && riskData.length > 0 &&
+        {riskData && riskData.length > 0 && (
           <>
-            <p>위험도 : {riskData.find(item => item.mean)?.A}점</p>
+            <p>위험도 : {riskData.find((item) => item.mean)?.A}점</p>
             <DangerList>
               {/* TODO : 경유지가 확실하게 2개 이상 있어야 오류없이 작동가능!! */}
               {/* TODO : 혹시 모를 예외에 대한 대비 필요 */}
-              {riskData.sort((a,b) => b.A - a.A).slice(0, 2).map((item) => (
-                <span key={`${item.risk}`}>🚨 주변에 <Facility>{item.risk}</Facility> 이(가) 없습니다!!</span>
-              ))}
+              {riskData
+                .sort((a, b) => b.A - a.A)
+                .slice(0, 2)
+                .map((item) => (
+                  <span key={`${item.risk}`}>
+                    🚨 주변에 <Facility>{item.risk}</Facility> 이(가) 없습니다!!
+                  </span>
+                ))}
             </DangerList>
           </>
-        }
+        )}
       </Content>
     </ChartWrapper>
   );

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -34,7 +34,7 @@ function Chart({ data, type }: ChartProps) {
         />
       </RadarChart>
       <Content>
-        {riskData && riskData.length > 0 ? (
+        {riskData && riskData.length > 0 &&
           <>
             <p>위험도 : {riskData.find(item => item.mean)?.A}점</p>
             <DangerList>
@@ -45,10 +45,7 @@ function Chart({ data, type }: ChartProps) {
               ))}
             </DangerList>
           </>
-        ) : (
-        // TODO : 로딩 중인지, 데이터가 없어서 오류가 난건지 사용자에게 알릴 필요가 있음 (그리고 여기도 스켈레톤 UI 적용하면 좋을 듯!!)
-          <span>데이터를 불러오는 중입니다...</span>
-        )}
+        }
       </Content>
     </ChartWrapper>
   );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -16,6 +16,7 @@ import { endNameState, endPositionState } from '../../recoil/atoms';
 import ep from '../../assets/images/ep.png';
 
 interface SearchBoxProps {
+  currentPosition: GeolocationPosition | undefined;
   searchState: SearchState;
   setSearchState: React.Dispatch<React.SetStateAction<SearchState>>;
   placeholder: string;
@@ -33,6 +34,7 @@ interface ContainerProps {
 }
 
 function SearchBox({
+  currentPosition,
   searchState,
   setSearchState,
   placeholder,
@@ -50,6 +52,15 @@ function SearchBox({
     });
   };
 
+  const selectCurrent = () => {
+    updateAddressFromCurrentCoordinates(
+      currentPosition,
+      setSearchState,
+      searchState,
+      setPosition,
+    );
+  };
+
   return (
     <SearchInput>
       <input
@@ -60,6 +71,9 @@ function SearchBox({
       />
       {isSearching && (
         <SearchResultContainer>
+          <button type="button" onClick={selectCurrent}>
+            현위치로 설정
+          </button>
           {places.map((place, index) => (
             <SearchResultList
               // eslint-disable-next-line react/no-array-index-key
@@ -114,12 +128,15 @@ function SearchContainer({ setStartPosition, map }: ContainerProps) {
   // 혹시 나중에 출발지나 도착지를 현재 위치로 변경하는 기능을 추가할 때 유용할 것 같습니다.
   useEffect(() => {
     if (!setStartPosition) return;
-    updateAddressFromCurrentCoordinates(
-      currentPosition,
-      setStartSearchState,
-      startSearchState,
-      setStartPosition,
-    );
+    const fetchAddress = async () => {
+      await updateAddressFromCurrentCoordinates(
+        currentPosition,
+        setStartSearchState,
+        startSearchState,
+        setStartPosition,
+      );
+    };
+    fetchAddress();
   }, [currentPosition]);
 
   useEffect(() => {
@@ -151,6 +168,7 @@ function SearchContainer({ setStartPosition, map }: ContainerProps) {
     <SearchWrapper>
       {setStartPosition && (
         <SearchBox
+          currentPosition={currentPosition}
           searchState={startSearchState}
           setSearchState={setStartSearchState}
           placeholder="출발지를 입력하세요"
@@ -159,6 +177,7 @@ function SearchContainer({ setStartPosition, map }: ContainerProps) {
         />
       )}
       <SearchBox
+        currentPosition={currentPosition}
         searchState={endSearchState}
         setSearchState={setEndSearchState}
         placeholder="도착지를 입력하세요"

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import { SkeletonWrapper, SkeletonText } from './style';
+import { SkeletonWrapper, SkeletonText, SkeletonChart, Group } from './style';
 
-function Skeleton() {
+function Skeleton({ type }: { type: string }) {
   return (
-    <SkeletonWrapper>
-      <SkeletonText />
-      <SkeletonText />
+    <SkeletonWrapper $type={type}>
+      {type === 'chart' && <SkeletonChart />}
+      {type === 'chart' ? (
+        <Group>
+          <SkeletonText />
+          <SkeletonText />
+        </Group>
+      ) : (
+        <>
+          <SkeletonText />
+          <SkeletonText />
+        </>
+      )}
     </SkeletonWrapper>
   );
 }

--- a/src/components/Skeleton/style.ts
+++ b/src/components/Skeleton/style.ts
@@ -9,25 +9,39 @@ const loadingAnimation = keyframes`
   }
 `;
 
-export const SkeletonWrapper = styled.div`
-  width: 80%;
-  height: 7rem;
+export const SkeletonWrapper = styled.div<{ $type?: string }>`
+  width: ${(props) => (props.$type === 'chart' ? '90%' : '80%')};
+  height: ${(props) => (props.$type === 'chart' ? '8rem' : '7rem')};
   border-radius: 0.4rem;
   display: flex;
-  flex-direction: column;
+  flex-direction: ${(props) => (props.$type === 'chart' ? 'row' : 'column')};
   gap: 0.7rem;
-  justify-content: center;
-  padding-inline: 1rem;
+  justify-content: ${(props) => (props.$type === 'chart' ? 'start' : 'center')};
+  padding: 1rem;
   background-color: #ffffff;
   box-shadow: 0 3px 4px rgba(0, 0, 0, 0.2);
   position: absolute;
-  bottom: 1.2rem;
+  bottom: ${(props) => (props.$type === 'chart' ? '6rem' : '1.2rem')};
 `;
 
 export const SkeletonText = styled.div`
   width: 6rem;
   height: 1.5rem;
-  border-radius: 0.8rem;
+  border-radius: 0.5rem;
   background: linear-gradient(90deg, #f1f0f0 0%, #e1e1e1 50%, #f1f0f0 100%);
   animation: ${loadingAnimation} 1.5s infinite;
+`;
+
+export const SkeletonChart = styled.div`
+  width: 10rem;
+  height: 6rem;
+  border-radius: 0.5rem;
+  background: linear-gradient(90deg, #f1f0f0 0%, #e1e1e1 50%, #f1f0f0 100%);
+  animation: ${loadingAnimation} 1.5s infinite;
+`;
+
+export const Group = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 `;

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -44,7 +44,7 @@ function DetailRoute() {
   });
 
   const waypoints = useMemo(() => {
-    if (!data) {
+    if (!data || data.length === 0) {
       return [];
     }
     // TODO : 잘못된 데이터가 들어갈 수 있음 (length를 보고 선택할 수 있는 알고리즘이 필요함)
@@ -55,7 +55,7 @@ function DetailRoute() {
     return data.slice(1, 4);
   }, [data]);
 
-  const mean = data ? data[data.length - 1][0] : null;
+  const mean = data && data.length > 0 ? data[data.length - 1][0] : null;
 
   useEffect(() => {
     if (!currentPosition) return;

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -1,14 +1,15 @@
+/* eslint-disable no-nested-ternary */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
-import { Coord, WaypointInfo } from '../types/mapTypes';
+import { WaypointInfo } from '../types/mapTypes';
 import Wrapper from '../components/common/Wrapper';
-import { endPositionState } from '../recoil/atoms';
+import { startPositionState, endPositionState } from '../recoil/atoms';
 import Chart from '../components/Chart';
 import ReportButton from '../components/ReportButton';
 import getWaypoints from '../api/routeAPI';
@@ -23,10 +24,7 @@ function DetailRoute() {
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
-  const [startPosition, setStartPosition] = useState<Coord>({
-    latitude: undefined,
-    longitude: undefined,
-  });
+  const [startPosition, setStartPosition] = useRecoilState(startPositionState);
   const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -65,7 +63,9 @@ function DetailRoute() {
   }, [map]);
 
   useEffect(() => {
-    if (!map) return;
+    // TODO: 거리가 짧아서 받아온 waypoints가 빈 배열인 경우와
+    // 경로 데이터를 아직 받아오지 못해서 waypoints가 빈 배열인 경우를 구분해야함
+    if (!map || waypoints.length === 0) return;
 
     drawRoute(
       map,

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -15,6 +15,7 @@ import ReportButton from '../components/ReportButton';
 import getWaypoints from '../api/routeAPI';
 import ReportModalContents from '../components/ModalContents/ReportModal';
 import Modal from '../components/common/Modal';
+import Skeleton from '../components/Skeleton';
 
 function DetailRoute() {
   const { currentPosition } = useCurrentPosition();
@@ -36,7 +37,7 @@ function DetailRoute() {
     number | undefined
   >();
 
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['waypoints', startPosition, endPosition],
     queryFn: () => getWaypoints(startPosition, endPosition),
     staleTime: 60000,
@@ -95,7 +96,9 @@ function DetailRoute() {
       <SearchContainer setStartPosition={setStartPosition} />
 
       <div id="map_div" ref={mapRef} />
-      {selectedMarkerId !== undefined ? (
+      {isLoading ? (
+        <Skeleton type="chart" />
+      ) : selectedMarkerId !== undefined ? (
         <Chart
           data={waypoints.find(
             (waypoint: WaypointInfo) => waypoint.id === selectedMarkerId,

--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -64,9 +64,10 @@ function DetailRoute() {
   }, [map]);
 
   useEffect(() => {
-    // TODO: 거리가 짧아서 받아온 waypoints가 빈 배열인 경우와
-    // 경로 데이터를 아직 받아오지 못해서 waypoints가 빈 배열인 경우를 구분해야함
-    if (!map || waypoints.length === 0) return;
+    // !data => 경유지 응답이 안 왔는데 티맵에 경로 요청 해서 먼저 그리는 것 방지
+    // !end || !start => 출도착지 없는데 티맵에 경로 요청 방지
+    if (!map || !endPosition.latitude || !startPosition.latitude || !data)
+      return;
 
     drawRoute(
       map,

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -83,7 +83,7 @@ function RouteExplorer() {
 
       <div id="map_div" ref={mapRef} />
       {isLoading ? (
-        <Skeleton />
+        <Skeleton type="info" />
       ) : (
         routeInfo && (
           <RouteCarousel

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -38,7 +38,8 @@ function RouteExplorer() {
   });
 
   const waypoints = useMemo(() => {
-    if (!data) {
+    // console.log('지금', data);
+    if (!data || data.length === 0) {
       return [];
     }
     return data.slice(1, 4);
@@ -56,7 +57,10 @@ function RouteExplorer() {
   }, [map]);
 
   useEffect(() => {
-    if (!map || waypoints.length === 0) return;
+    // !data => 경유지 응답이 안 왔는데 티맵에 경로 요청 해서 먼저 그리는 것 방지
+    // !end || !start => 출도착지 없는데 티맵에 경로 요청 방지
+    if (!map || !endPosition.latitude || !startPosition.latitude || !data)
+      return;
 
     drawRoute(map, startPosition, endPosition, waypoints, polylines, markers)
       .then(({ newPolylines, newMarkers, tTime, tDistance }) => {

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -78,7 +78,7 @@ function RouteExplorer() {
   }, [map, startPosition, endPosition, waypoints]);
 
   const onClick = () => {
-    navigate('/route-detail');
+    if (waypoints.length > 0) navigate('/route-detail');
   };
 
   return (

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -1,17 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import getWaypoints from '../api/routeAPI';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
 import { generateMarker, drawRoute } from '../utils/mapUtils';
 import SearchContainer from '../components/Search';
-import { Coord } from '../types/mapTypes';
+import { startPositionState, endPositionState } from '../recoil/atoms';
 import RouteCarousel from '../components/RouteCarousel';
 import Wrapper from '../components/common/Wrapper';
-import { endPositionState } from '../recoil/atoms';
 import Skeleton from '../components/Skeleton';
 
 function RouteExplorer() {
@@ -23,10 +22,7 @@ function RouteExplorer() {
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
-  const [startPosition, setStartPosition] = useState<Coord>({
-    latitude: undefined,
-    longitude: undefined,
-  });
+  const [startPosition, setStartPosition] = useRecoilState(startPositionState);
   const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -60,7 +56,8 @@ function RouteExplorer() {
   }, [map]);
 
   useEffect(() => {
-    if (waypoints.length === 0) return;
+    if (!map || waypoints.length === 0) return;
+
     drawRoute(map, startPosition, endPosition, waypoints, polylines, markers)
       .then(({ newPolylines, newMarkers, tTime, tDistance }) => {
         setPolylines(newPolylines);

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -21,6 +21,14 @@ export const endNameState = atom<string>({
   default: '',
 });
 
+export const startPositionState = atom<Coord>({
+  key: 'startPositionState',
+  default: {
+    latitude: undefined,
+    longitude: undefined,
+  },
+});
+
 export const endPositionState = atom<Coord>({
   key: 'endPositionState',
   default: {
@@ -31,5 +39,5 @@ export const endPositionState = atom<Coord>({
 
 export const toastState = atom<ToastStateType | null>({
   key: 'toastState',
-  default: null
+  default: null,
 });

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -282,9 +282,11 @@ export const drawRoute = async (
       endName: '도착지',
       endX: String(endPosition.longitude),
       endY: String(endPosition.latitude),
-      passList: waypoints
-        .map((waypoint) => `${waypoint.longitude},${waypoint.latitude}`)
-        .join('_'),
+      ...(waypoints.length > 0 && {
+        passList: waypoints
+          .map((waypoint) => `${waypoint.longitude},${waypoint.latitude}`)
+          .join('_'),
+      }),
       reqCoordType: 'WGS84GEO',
       resCoordType: 'WGS84GEO',
       searchOption: 0,

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -169,24 +169,25 @@ export async function reverseGeo(lon: number, lat: number) {
 
 export async function updateAddressFromCurrentCoordinates(
   currentPosition: GeolocationPosition | undefined,
-  setStartSearchState: React.Dispatch<React.SetStateAction<SearchState>>,
-  startSearchState: SearchState,
-  setStartPosition: React.Dispatch<React.SetStateAction<Coord>>,
+  setSearchState: React.Dispatch<React.SetStateAction<SearchState>>,
+  searchState: SearchState,
+  setPosition: React.Dispatch<React.SetStateAction<Coord>>,
 ) {
   if (!currentPosition) return;
+
   const response = await reverseGeo(
     currentPosition?.coords.longitude,
     currentPosition?.coords.latitude,
   );
 
-  // console.log(response);
   // TODO: response가 null이 되지 않게
-  setStartSearchState({
-    ...startSearchState,
+  setSearchState({
+    ...searchState,
+    isSearching: false,
     selectedName: response!,
   });
 
-  setStartPosition({
+  setPosition({
     longitude: currentPosition?.coords.longitude,
     latitude: currentPosition?.coords.latitude,
   });


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
출발, 도착지를 현위치로 선택 가능하게 만들었습니다. 이 작업을 하다 보니 경유지 api 응답에 경유지 개수가 0인 경우 에러가 많이 나서 해결하기 위해 예외 처리를 추가했습니다.

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 출발 도착지 현위치 선택 버튼 추가 => 아직 수정이 필요합니다. 예외 처리 에러가 너무 많아 해결하다가 이번 pr 먼저 날리고 해결하기로 했습니다. 그래서 아직 뒤로가면 출발지는 여전히 현위치입니다.
- [x] 경유지 응답이 안 왔는데 티맵에 경로 요청을 먼저 한다던가 출발, 도착지가 없는데 티맵에 경로 요청을 하는 등의 불필요한 api 요청을 하지 않도록 수정했습니다. 
- [x] 차트 부분 스켈레톤 UI를 만들었는데 일단 RouteDetail 페이지에 넣어놨습니다. 너무 커밋이 많아지기 전에 pr 날리느라 제가 작업한 위치로 날렸는데 민수님이 설정해둔 위치가 더 괜찮아 보여 옮길 예정입니다!

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #103 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- 작업 내용이 많아지다보니 헷갈려져서 pr 먼저 날리고 해결하겠습니다!
- 경유지 api 응답을 보면 '위치 좌표를 찾을 수 없다'는 에러 메세지가 status 200으로 옵니다. catch에서 에러가 안 잡혀서 getWaypoints에서 response.data.errorMessage가 있으면 빈 배열을 리턴하도록 해놨는데 백엔드분들과 상의가 필요할 듯 합니다~! 이 부분은 먼저 출,도착지 버그부터 해결하고 이야기 하려구요!!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
