### PR TITLE
fix: 페이지 변경되면 시작점이 현위치로 바뀌는 버그 해결

### DIFF
--- a/src/pages/DetailRoute.tsx
+++ b/src/pages/DetailRoute.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import useMap from '../hooks/useMap';
 import useCurrentPosition from '../hooks/useCurruntPosition';
@@ -25,7 +25,7 @@ function DetailRoute() {
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
-  const [startPosition, setStartPosition] = useRecoilState(startPositionState);
+  const startPosition = useRecoilValue(startPositionState);
   const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -100,7 +100,7 @@ function DetailRoute() {
 
   return (
     <Wrapper>
-      <SearchContainer setStartPosition={setStartPosition} />
+      <SearchContainer type="start" />
 
       <div id="map_div" ref={mapRef} />
       {isLoading ? (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ function Home() {
 
   return (
     <Wrapper>
-      <SearchContainer map={map} />
+      <SearchContainer map={map} type="end" />
       <div id="map_div" ref={mapRef} />
       <BottomSheet />
     </Wrapper>

--- a/src/pages/RouteExplorer.tsx
+++ b/src/pages/RouteExplorer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue, useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import getWaypoints from '../api/routeAPI';
 import useMap from '../hooks/useMap';
@@ -22,7 +22,7 @@ function RouteExplorer() {
     currentPosition?.coords.latitude,
     currentPosition?.coords.longitude,
   );
-  const [startPosition, setStartPosition] = useRecoilState(startPositionState);
+  const startPosition = useRecoilValue(startPositionState);
   const endPosition = useRecoilValue(endPositionState);
   const [polylines, setPolylines] = useState<any[]>([]);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -83,7 +83,7 @@ function RouteExplorer() {
 
   return (
     <Wrapper>
-      <SearchContainer setStartPosition={setStartPosition} />
+      <SearchContainer type="start" />
 
       <div id="map_div" ref={mapRef} />
       {isLoading ? (

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -21,6 +21,11 @@ export const endNameState = atom<string>({
   default: '',
 });
 
+export const startNameState = atom<string>({
+  key: 'startNameState',
+  default: '',
+});
+
 export const startPositionState = atom<Coord>({
   key: 'startPositionState',
   default: {

--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -179,6 +179,7 @@ export async function updateAddressFromCurrentCoordinates(
   setSearchState: React.Dispatch<React.SetStateAction<SearchState>>,
   searchState: SearchState,
   setPosition: React.Dispatch<React.SetStateAction<Coord>>,
+  setName: React.Dispatch<React.SetStateAction<string>>,
 ) {
   if (!currentPosition) return;
 
@@ -187,12 +188,16 @@ export async function updateAddressFromCurrentCoordinates(
     currentPosition?.coords.latitude,
   );
 
+  // console.log('좌표를 주소로 변환중', 'selectedName:', response);
+
   // TODO: response가 null이 되지 않게
   setSearchState({
     ...searchState,
     isSearching: false,
     selectedName: response!,
   });
+
+  setName(response!);
 
   setPosition({
     longitude: currentPosition?.coords.longitude,


### PR DESCRIPTION
### 개요
<!-- 이 PR이 왜 필요한지 간단히 설명해주세요 -->
검색 컴포넌트에서 페이지 변경시 시작점이 현위치로 변경되는 버그를 수정했습니다~!

### 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 자세히 설명해주세요. 변경된 내용을 목록 혹은 체크리스트로 나열해주세요 -->

- [x] 출발지의 이름, 좌표 모두 recoil로 관리하도록 변경했습니다.

### 관련 이슈
<!-- 이 PR과 관련된 이슈가 있다면 여기에 링크를 포함해주세요 -->

Closes #112 

### 질문
<!-- 궁금한 점이나 주의해서 봐야할 부분이 있다면 알려주세요 -->
- 버그는 해결되었는데 좀 더 깔끔하게 만들어야 할 것 같아서 리팩토링이 필요할 것 같습니다!

### 스크린샷 (선택 사항)
<!-- 변경된 화면이나 기능을 보여주는 스크린샷이 있다면 여기에 첨부해주세요 -->
